### PR TITLE
Added Lithops appliance code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+community-apps/build
+community-apps/export
+community-apps/version
+community-apps/Makefile.local

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "one-apps"]
+	path = one-apps
+	url = https://github.com/OpenNebula/one-apps.git

--- a/appliances/service/695ab19e-23dc-11ef-a2b8-59beec9fdf86.yaml
+++ b/appliances/service/695ab19e-23dc-11ef-a2b8-59beec9fdf86.yaml
@@ -5,7 +5,7 @@ publisher: OpenNebula Systems
 description: |-
   Appliance with preinstalled [Lithops](https://lithops-cloud.github.io/docs/) and Docker for k8s backend.
 
-  See the dedicated [documentation](https://github.com/OpenNebula/one-apps/wiki/lithops_quick).
+  See the dedicated [documentation](https://github.com/OpenNebula/marketplace-community/wiki/lithops_quick).
 short_description: Appliance with preinstalled Lithops for KVM hosts
 tags:
 - lithops

--- a/community-apps/Makefile
+++ b/community-apps/Makefile
@@ -1,0 +1,38 @@
+# load variables and makefile config
+include Makefile.config
+
+# load possible overrides or non-free definitions
+-include Makefile.local
+
+# services
+services: $(patsubst %, packer-%, $(SERVICES))
+
+# allow individual services targets (e.g., "make service_Lithops")
+$(SERVICES):  %: packer-% ;
+
+# aliases + dependency
+packer-%: ${DIR_EXPORT}/%.qcow2
+	@${INFO} "Packer ${*} done"
+
+# run packer build for given distro or service
+${DIR_EXPORT}/%.qcow2: $(patsubst %, ${DIR_ONEAPPS}/context-linux/out/%, $(LINUX_CONTEXT_PACKAGES))
+	$(eval DISTRO_NAME := $(shell echo ${*} | sed 's/[0-9].*//'))
+	$(eval DISTRO_VER  := $(shell echo ${*} | sed 's/^.[^0-9]*\(.*\)/\1/'))
+	packer/build.sh "${DISTRO_NAME}" "${DISTRO_VER}" ${@}
+
+clean:
+	-rm -rf ${DIR_EXPORT}/*
+
+help:
+	@echo 'Usage examples:'
+	@echo '    make <service>         -- build just one service'
+	@echo
+	@echo '    make services          -- build all services'
+	@echo '    make services -j 4     -- build all services in 4 parallel tasks'
+	@echo
+	@echo 'Available services:'
+	@echo '    $(SERVICES)'
+	@echo
+
+version:
+	@echo $(VERSION)-$(RELEASE) > version

--- a/community-apps/Makefile.config
+++ b/community-apps/Makefile.config
@@ -1,0 +1,27 @@
+# context version definition
+VERSION := 6.10.0
+RELEASE := 1
+
+# log
+VERBOSE         := 1
+PACKER_LOG      := 0
+PACKER_HEADLESS := true
+
+SERVICES := service_Lithops
+
+.DEFAULT_GOAL := help
+
+# default directories
+DIR_ONEAPPS := ../one-apps
+DIR_BUILD  := build
+DIR_EXPORT := export
+$(shell mkdir -p ${DIR_BUILD} ${DIR_EXPORT})
+
+# don't delete exported
+.SECONDARY: $(patsubst %, $(DIR_EXPORT)/%.qcow2, $(SERVICES))
+
+# logging func
+INFO=sh -c 'if [ $(VERBOSE) = 1 ]; then  echo [INFO] $$1; fi' INFO
+
+# export all variables
+export

--- a/community-apps/appliances/Lithops/appliance.sh
+++ b/community-apps/appliances/Lithops/appliance.sh
@@ -1,0 +1,254 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2024, OpenNebula Project, OpenNebula Systems                  #
+#                                                                              #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may      #
+# not use this file except in compliance with the License. You may obtain      #
+# a copy of the License at                                                     #
+#                                                                              #
+# http://www.apache.org/licenses/LICENSE-2.0                                   #
+#                                                                              #
+# Unless required by applicable law or agreed to in writing, software          #
+# distributed under the License is distributed on an "AS IS" BASIS,            #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.     #
+# See the License for the specific language governing permissions and          #
+# limitations under the License.                                               #
+# ---------------------------------------------------------------------------- #
+set -o errexit -o pipefail
+
+
+# List of contextualization parameters
+ONE_SERVICE_PARAMS=(
+    'ONEAPP_LITHOPS_BACKEND'            'configure'  'Lithops compute backend'                                          'O|text'
+    'ONEAPP_LITHOPS_STORAGE'            'configure'  'Lithops storage backend'                                          'O|text'
+    'ONEAPP_MINIO_ENDPOINT'             'configure'  'Lithops storage backend MinIO endpoint URL'                       'O|text'
+    'ONEAPP_MINIO_ACCESS_KEY_ID'        'configure'  'Lithops storage backend MinIO account user access key'            'O|text'
+    'ONEAPP_MINIO_SECRET_ACCESS_KEY'    'configure'  'Lithops storage backend MinIO account user secret access key'     'O|text'
+    'ONEAPP_MINIO_BUCKET'              'configure'  'Lithops storage backend MinIO existing bucket'                    'O|text'
+    'ONEAPP_MINIO_ENDPOINT_CERT'        'configure'  'Lithops storage backend MinIO endpoint certificate'               'O|text64'
+)
+
+
+### Appliance metadata ###############################################
+
+# Appliance metadata
+ONE_SERVICE_NAME='Service Lithops - KVM'
+ONE_SERVICE_VERSION='3.4.0'   #latest
+ONE_SERVICE_BUILD=$(date +%s)
+ONE_SERVICE_SHORT_DESCRIPTION='Appliance with preinstalled Lithops for KVM hosts'
+ONE_SERVICE_DESCRIPTION=$(cat <<EOF
+Appliance with preinstalled Lithops v3.4.0.
+
+By default, it uses localhost both for Compute and Storage Backend.
+
+To configure MinIO as Storage Backend use the parameter ONEAPP_LITHOPS_STORAGE=minio
+with ONEAPP_MINIO_ENDPOINT, ONEAPP_MINIO_ACCESS_KEY_ID and ONEAPP_MINIO_SECRET_ACCESS_KEY.
+These parameters values have to point to a valid and reachable MinIO server endpoint.
+
+The parameter ONEAPP_MINIO_BUCKET and ONEAPP_MINIO_ENDPOINT_CERT are optional.
+- ONEAPP_MINIO_BUCKET points to an existing bucket in the MinIO server. If the bucket does not exist or if the
+parameter is empty, the MinIO server will generate a bucket automatically.
+- ONEAPP_MINIO_ENDPOINT_CERT is necessary when using self-signed certificates on the MinIO server. This is the
+certificate for the CA on the MinIO server. If the CA certificate exists, script will skip it,
+if one would want to update the CA certificate from context, first delete previous ca.crt file.
+EOF
+)
+ONE_SERVICE_RECONFIGURABLE=true
+
+### Contextualization defaults #######################################
+
+ONEAPP_LITHOPS_BACKEND="${ONEAPP_LITHOPS_BACKEND:-localhost}"
+ONEAPP_LITHOPS_STORAGE="${ONEAPP_LITHOPS_STORAGE:-localhost}"
+
+### Globals ##########################################################
+
+DEP_PKGS="python3-pip"
+DEP_PIP="boto3"
+LITHOPS_VERSION="3.4.0"
+DOCKER_VERSION="5:26.1.3-1~ubuntu.22.04~jammy"
+
+###############################################################################
+###############################################################################
+###############################################################################
+
+#
+# service implementation
+#
+
+service_cleanup()
+{
+    :
+}
+
+service_install()
+{
+    # ensuring that the setup directory exists
+    #TODO: move to service
+    mkdir -p "$ONE_SERVICE_SETUP_DIR"
+    export DEBIAN_FRONTEND=noninteractive
+
+    # packages
+    install_deps ${DEP_PKGS} ${DEP_PIP}
+
+    # docker
+    install_docker
+
+    # Lithops
+    install_lithops
+
+    # create Lithops config file in /etc/lithops
+    create_lithops_config
+
+    # service metadata
+    create_one_service_metadata
+
+    # cleanup
+    postinstall_cleanup
+
+    msg info "INSTALLATION FINISHED"
+
+    return 0
+}
+
+service_configure()
+{
+    # update Lithops config file if non-default options are set
+    update_lithops_config
+
+    local_ca_folder="/usr/local/share/ca-certificates/minio"
+    if [[ ! -z "${ONEAPP_MINIO_ENDPOINT_CERT}" ]] && [[ ! -f "${local_ca_folder}/ca.crt" ]]; then
+        msg info "Adding trust CA for MinIO endpoint"
+
+        if [[ ! -d "${local_ca_folder}" ]]; then
+            msg info "Create folder ${local_ca_folder}"
+            mkdir "${local_ca_folder}"
+        fi
+
+        msg info "Create CA file and update certificates"
+        echo ${ONEAPP_MINIO_ENDPOINT_CERT} | base64 --decode >> ${local_ca_folder}/ca.crt
+        update-ca-certificates
+    fi
+
+    return 0
+}
+
+service_bootstrap()
+{
+    update_lithops_config
+    return 0
+}
+
+###############################################################################
+###############################################################################
+###############################################################################
+
+#
+# functions
+#
+
+install_deps()
+{
+    msg info "Run apt-get update"
+    apt-get update
+
+    msg info "Install required packages for Lithops"
+    if ! apt-get install -y "${1}" ; then
+        msg error "Package(s) installation failed: ${1}"
+        exit 1
+    fi
+
+    msg info "Install pip dependencies"
+    if ! pip install "${2}" ; then
+        msg error "Python pip dependencies installation failed"
+        exit 1
+    fi
+}
+
+install_docker()
+{
+    msg info "Add Docker official GPG key"
+    install -m 0755 -d /etc/apt/keyrings
+
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+
+    chmod a+r /etc/apt/keyrings/docker.asc
+
+    msg info "Add Docker repository to apt sources"
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    apt update
+
+    msg info "Install Docker Engine"
+    if ! apt-get install -y docker-ce=$DOCKER_VERSION docker-ce-cli=$DOCKER_VERSION containerd.io docker-buildx-plugin docker-compose-plugin ; then
+        msg error "Docker installation failed"
+        exit 1
+    fi
+}
+
+install_lithops()
+{
+    msg info "Install Lithops from pip"
+    if ! pip install lithops==${LITHOPS_VERSION} ; then
+        msg error "Error installing Lithops"
+        exit 1
+    fi
+
+    msg info "Create /etc/lithops folder"
+    mkdir /etc/lithops
+}
+
+create_lithops_config()
+{
+    msg info "Create default config file"
+    cat > /etc/lithops/config <<EOF
+lithops:
+  backend: localhost
+  storage: localhost
+
+# Start Compute Backend configuration
+# End Compute Backend configuration
+
+# Start Storage Backend configuration
+# End Storage Backend configuration
+EOF
+}
+
+update_lithops_config(){
+    msg info "Update compute and storage backend modes"
+    sed -i "s/backend: .*/backend: ${ONEAPP_LITHOPS_BACKEND}/g" /etc/lithops/config
+    sed -i "s/storage: .*/storage: ${ONEAPP_LITHOPS_STORAGE}/g" /etc/lithops/config
+
+    if [[ ${ONEAPP_LITHOPS_STORAGE} = "localhost" ]]; then
+        msg info "Edit config file for localhost Storage Backend"
+        sed -i -ne "/# Start Storage/ {p;" -e ":a; n; /# End Storage/ {p; b}; ba}; p" /etc/lithops/config
+    elif [[ ${ONEAPP_LITHOPS_STORAGE} = "minio" ]]; then
+        msg info "Edit config file for MinIO Storage Backend"
+        if ! check_minio_attrs; then
+            echo
+            msg error "MinIO configuration failed"
+            msg info "You have to provide endpoint, access key id and secrec access key to configure MinIO storage backend"
+            exit 1
+        else
+            msg info "Adding MinIO configuration to /etc/lithops/config"
+            sed -i -ne "/# Start Storage/ {p; iminio:\n  endpoint: ${ONEAPP_MINIO_ENDPOINT}\n  access_key_id: ${ONEAPP_MINIO_ACCESS_KEY_ID}\n  secret_access_key: ${ONEAPP_MINIO_SECRET_ACCESS_KEY}\n  storage_bucket: ${ONEAPP_MINIO_BUCKET}" -e ":a; n; /# End Storage/ {p; b}; ba}; p" /etc/lithops/config
+        fi
+    fi
+}
+
+check_minio_attrs()
+{
+    [[ -z "$ONEAPP_MINIO_ENDPOINT" ]] && return 1
+    [[ -z "$ONEAPP_MINIO_ACCESS_KEY_ID" ]] && return 1
+    [[ -z "$ONEAPP_MINIO_SECRET_ACCESS_KEY" ]] && return 1
+
+    return 0
+}
+
+postinstall_cleanup()
+{
+    msg info "Delete cache and stored packages"
+    apt-get autoclean
+    apt-get autoremove
+    rm -rf /var/lib/apt/lists/*
+}
+

--- a/community-apps/packer/build.sh
+++ b/community-apps/packer/build.sh
@@ -1,0 +1,1 @@
+../../one-apps/packer/build.sh

--- a/community-apps/packer/service_Lithops/81-configure-ssh.sh
+++ b/community-apps/packer/service_Lithops/81-configure-ssh.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Configures critical settings for OpenSSH server.
+
+exec 1>&2
+set -eux -o pipefail
+
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "PasswordAuthentication no" }
+/^[#\s]*PasswordAuthentication\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "PermitRootLogin without-password" }
+/^[#\s]*PermitRootLogin\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "UseDNS no" }
+/^[#\s]*UseDNS\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+sync

--- a/community-apps/packer/service_Lithops/82-configure-context.sh
+++ b/community-apps/packer/service_Lithops/82-configure-context.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Configure and enable service context.
+
+exec 1>&2
+set -eux -o pipefail
+
+mv /etc/one-appliance/net-90-service-appliance /etc/one-context.d/
+mv /etc/one-appliance/net-99-report-ready      /etc/one-context.d/
+
+chown root:root /etc/one-context.d/*
+chmod u=rwx,go=rx /etc/one-context.d/*
+
+sync

--- a/community-apps/packer/service_Lithops/Lithops.pkr.hcl
+++ b/community-apps/packer/service_Lithops/Lithops.pkr.hcl
@@ -1,0 +1,107 @@
+source "null" "null" { communicator = "none" }
+
+build {
+  sources = ["source.null.null"]
+
+  provisioner "shell-local" {
+    inline = [
+      "mkdir -p ${var.input_dir}/context",
+      "${var.input_dir}/gen_context > ${var.input_dir}/context/context.sh",
+      "mkisofs -o ${var.input_dir}/${var.appliance_name}-context.iso -V CONTEXT -J -R ${var.input_dir}/context",
+    ]
+  }
+}
+
+# Build VM image
+source "qemu" "Lithops" {
+  cpus        = 2
+  memory      = 2048
+  accelerator = "kvm"
+
+  iso_url      = "../one-apps/export/ubuntu2204.qcow2"
+  iso_checksum = "none"
+
+  headless = var.headless
+
+  disk_image       = true
+  disk_cache       = "unsafe"
+  disk_interface   = "virtio"
+  net_device       = "virtio-net"
+  format           = "qcow2"
+  disk_compression = false
+  disk_size        = "5000"
+
+  output_directory = var.output_dir
+
+  qemuargs = [
+    ["-cpu", "host"],
+    ["-cdrom", "${var.input_dir}/${var.appliance_name}-context.iso"],
+    ["-serial", "stdio"],
+    # MAC addr needs to mach ETH0_MAC from context iso
+    ["-netdev", "user,id=net0,hostfwd=tcp::{{ .SSHHostPort }}-:22"],
+    ["-device", "virtio-net-pci,netdev=net0,mac=00:11:22:33:44:55"]
+  ]
+  ssh_username     = "root"
+  ssh_password     = "opennebula"
+  ssh_timeout      = "900s"
+  shutdown_command = "poweroff"
+  vm_name          = "${var.appliance_name}"
+}
+
+build {
+  sources = ["source.qemu.Lithops"]
+
+  # revert insecure ssh options done by context start_script
+  provisioner "shell" {
+    scripts = ["${var.input_dir}/81-configure-ssh.sh"]
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -e"
+    inline = [
+      "install -o 0 -g 0 -m u=rwx,g=rx,o=   -d /etc/one-appliance/{,service.d/,lib/}",
+      "install -o 0 -g 0 -m u=rwx,g=rx,o=rx -d /opt/one-appliance/{,bin/}",
+    ]
+  }
+
+  provisioner "file" {
+    sources = [
+      "../one-apps/appliances/scripts/net-90-service-appliance",
+      "../one-apps/appliances/scripts/net-99-report-ready",
+    ]
+    destination = "/etc/one-appliance/"
+  }
+  provisioner "file" {
+    sources = [
+      "../one-apps/appliances/lib/common.sh",
+      "../one-apps/appliances/lib/functions.sh",
+    ]
+    destination = "/etc/one-appliance/lib/"
+  }
+  provisioner "file" {
+    source      = "../one-apps/appliances/service.sh"
+    destination = "/etc/one-appliance/service"
+  }
+  provisioner "file" {
+    sources     = ["appliances/Lithops/appliance.sh"]
+    destination = "/etc/one-appliance/service.d/"
+  }
+
+  provisioner "shell" {
+    scripts = ["${var.input_dir}/82-configure-context.sh"]
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -e"
+    inline         = ["/etc/one-appliance/service install && sync"]
+  }
+
+  post-processor "shell-local" {
+    execute_command = ["bash", "-c", "{{.Vars}} {{.Script}}"]
+    environment_vars = [
+      "OUTPUT_DIR=${var.output_dir}",
+      "APPLIANCE_NAME=${var.appliance_name}",
+    ]
+    scripts = ["../one-apps/packer/postprocess.sh"]
+  }
+}

--- a/community-apps/packer/service_Lithops/gen_context
+++ b/community-apps/packer/service_Lithops/gen_context
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eux -o pipefail
+
+SCRIPT=$(cat <<'MAINEND'
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "PasswordAuthentication yes" }
+/^[#\s]*PasswordAuthentication\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "PermitRootLogin yes" }
+/^[#\s]*PermitRootLogin\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+systemctl reload sshd
+
+echo "nameserver 1.1.1.1" > /etc/resolv.conf
+MAINEND
+)
+
+cat<<EOF
+ETH0_METHOD='dhcp'
+NETWORK='YES'
+SET_HOSTNAME='Lithops'
+PASSWORD='opennebula'
+ETH0_MAC='00:11:22:33:44:55'
+NETCFG_TYPE='nm'
+START_SCRIPT_BASE64="$(echo "$SCRIPT" | base64 -w0)"
+EOF

--- a/community-apps/packer/service_Lithops/plugins.pkr.hcl
+++ b/community-apps/packer/service_Lithops/plugins.pkr.hcl
@@ -1,0 +1,1 @@
+../../../one-apps/packer/plugins.pkr.hcl

--- a/community-apps/packer/service_Lithops/variables.pkr.hcl
+++ b/community-apps/packer/service_Lithops/variables.pkr.hcl
@@ -1,0 +1,22 @@
+variable "appliance_name" {
+  type    = string
+  default = "service_Lithops"
+}
+
+variable "input_dir" {
+  type = string
+}
+
+variable "output_dir" {
+  type = string
+}
+
+variable "headless" {
+  type    = bool
+  default = false
+}
+
+variable "version" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
Added Lithops appliance code to this repo, instead of one-apps repo. For this:

- Added OpenNebula/one-apps repository as a submodule
- Added community-apps folder for apps belonging to this Community Marketplace. This folder contains:
  - appliances folder -> Contains a folder with appliance name and .sh file
  - Makefile, Makefile.config -> Adapted from one-apps repo, but simplified to just build services
  - packer folder -> Contains symlink to build.sh on one-apps and the folder with packer files for each service
- Added .gitignore file to ignore artifacts generated from the community-apps make file

Updated Lithops appliance metadata so documentation link points to correct URL on OpenNebula/marketplace-community.wiki.