### PR TITLE
F OpenNebula/cluster-api-provider-opennebula#10: Ubuntu2204 for CAPONE appliance

### DIFF
--- a/apps-code/community-apps/packer/capone/capone.pkr.hcl
+++ b/apps-code/community-apps/packer/capone/capone.pkr.hcl
@@ -19,7 +19,7 @@ source "qemu" "capone" {
   memory      = 2048
   accelerator = "kvm"
 
-  iso_url      = "../one-apps/export/ubuntu2404.qcow2"
+  iso_url      = "../one-apps/export/ubuntu2204.qcow2"
   iso_checksum = "none"
 
   headless = var.headless


### PR DESCRIPTION
Change CAPONE base image to Ubuntu 22.04 due to a bug with Network Manager found in Ubuntu 24.04