### PR TITLE
M #-: Update CAPONE 131

### DIFF
--- a/apps-code/community-apps/packer/capone/40-containerd.sh.131
+++ b/apps-code/community-apps/packer/capone/40-containerd.sh.131
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-: "${CNI_PLUGINS_VERSION:=1.5.1}"
-: "${CONTAINERD_VERSION:=1.7.22}"
-: "${RUNC_VERSION:=1.1.14}"
+: "${CNI_PLUGINS_VERSION:=1.6.2}"
+: "${CONTAINERD_VERSION:=2.0.2}"
+: "${RUNC_VERSION:=1.2.4}"
 
 exec 1>&2
 set -eux -o pipefail
@@ -36,8 +36,6 @@ curl -fsSL "https://github.com/containernetworking/plugins/releases/download/v$C
 curl -fsSL "https://github.com/containerd/containerd/releases/download/v$CONTAINERD_VERSION/containerd-static-$CONTAINERD_VERSION-linux-amd64.tar.gz" \
 | tar -xz -f- -C /usr/local/bin/ --strip-components=1 --no-same-owner \
   bin/containerd \
-  bin/containerd-shim \
-  bin/containerd-shim-runc-v1 \
   bin/containerd-shim-runc-v2 \
   bin/containerd-stress \
   bin/ctr

--- a/apps-code/community-apps/packer/capone/41-kubernetes.sh.131
+++ b/apps-code/community-apps/packer/capone/41-kubernetes.sh.131
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 
 : "${CRICTL_VERSION:=1.31.1}"
-: "${HELM_VERSION:=3.16.0}"
-: "${KUBERNETES_RELEASE_VERSION:=0.17.8}"
-: "${KUBERNETES_VERSION:=1.31.1}"
-: "${KUBEVIP_CLOUD_PROVIDER_VERSION:=0.0.10}"
-: "${KUBEVIP_VERSION:=0.8.3}"
+: "${HELM_VERSION:=3.16.2}"
+: "${KUBERNETES_RELEASE_VERSION:=0.17.12}"
+: "${KUBERNETES_VERSION:=1.31.4}"
+: "${KUBEVIP_CLOUD_PROVIDER_VERSION:=0.0.11}"
+: "${KUBEVIP_VERSION:=0.8.9}"
+: "${FLANNEL_VERSION:=0.26.3}"
 
 exec 1>&2
 set -eux -o pipefail
@@ -58,6 +59,11 @@ kubeadm config images pull "--kubernetes-version=v$KUBERNETES_VERSION"
 
 ctr --namespace=k8s.io image pull "ghcr.io/kube-vip/kube-vip:v$KUBEVIP_VERSION"
 ctr --namespace=k8s.io image pull "ghcr.io/kube-vip/kube-vip-cloud-provider:v$KUBEVIP_CLOUD_PROVIDER_VERSION"
+
+curl -fsSL "https://github.com/flannel-io/flannel/releases/download/v$FLANNEL_VERSION/kube-flannel.yml" | gawk -f /dev/fd/3 3<<'AWK'
+/^ *image:/ { seen[$2]++ }
+END { for (img in seen) system("ctr --namespace=k8s.io image pull " img) }
+AWK
 
 install -m u=rwx,go=rx /dev/fd/0 /usr/local/bin/kube-vip <<EOF
 #!/usr/bin/env bash

--- a/apps-code/community-apps/packer/capone/capone.pkr.hcl
+++ b/apps-code/community-apps/packer/capone/capone.pkr.hcl
@@ -19,7 +19,7 @@ source "qemu" "capone" {
   memory      = 2048
   accelerator = "kvm"
 
-  iso_url      = "../one-apps/export/ubuntu2204.qcow2"
+  iso_url      = "../one-apps/export/ubuntu2204oneke.qcow2"
   iso_checksum = "none"
 
   headless = var.headless


### PR DESCRIPTION
- CNI_PLUGINS: 1.5.1 -> 1.6.2
- CONTAINERD: 1.7.22 -> 2.0.2
- RUNC: 1.1.14 -> 1.2.3
- HELM: 3.16.0 -> 3.16.2
- KUBERNETES_RELEASE: 0.17.8 -> 0.17.12
- KUBERNETES: 1.31.1 -> 1.31.4
- KUBEVIP_CLOUD_PROVIDER: 0.0.10 -> 0.0.11
- KUBEVIP: 0.8.3 -> 0.8.9
- FLANNEL: 0.26.3 (new)
- Use ubuntu2204oneke as the base image for CAPONE