### PR TITLE
F OpenNebula/engineering#336: [Cloudless Project] Update Lithops service architecture

### DIFF
--- a/appliances/LithopsService/01076f79-94be-4c8f-b57f-dec96d5d15a4.yaml
+++ b/appliances/LithopsService/01076f79-94be-4c8f-b57f-dec96d5d15a4.yaml
@@ -1,6 +1,6 @@
 ---
-name: Lithops Service - Client
-version: 6.10.0-2-20241018
+name: Lithops - Client
+version: 6.10.0-3-20250513
 publisher: OpenNebula Systems
 description: |-
   Appliance with preinstalled [Lithops](https://lithops-cloud.github.io/docs/).
@@ -15,7 +15,7 @@ tags:
 - service
 type: VMTEMPLATE
 format: qcow2
-creation_time: 1734631373
+creation_time: 1747149743
 os-id: Ubuntu
 os-release: '22.04 LTS'
 os-arch: x86_64
@@ -29,7 +29,7 @@ opennebula_template:
     oneapp_lithops_backend: '$ONEAPP_LITHOPS_BACKEND'
     oneapp_lithops_standalone: 'NO'
     oneapp_lithops_storage: '$ONEAPP_LITHOPS_STORAGE'
-    oneapp_minio_access_key_id: '$ONEAPP_MINIO_ACCESS_KEY_ID"'
+    oneapp_minio_access_key_id: '$ONEAPP_MINIO_ACCESS_KEY_ID'
     oneapp_minio_bucket: '$ONEAPP_MINIO_BUCKET'
     oneapp_minio_endpoint: '$ONEAPP_MINIO_ENDPOINT'
     oneapp_minio_endpoint_cert: '$ONEAPP_MINIO_ENDPOINT_CERT'
@@ -41,6 +41,14 @@ opennebula_template:
     oneapp_onebe_kubecfg_path: '$ONEAPP_ONEBE_KUBECFG_PATH'
     oneapp_onebe_runtime_cpu: '$ONEAPP_ONEBE_RUNTIME_CPU'
     oneapp_onebe_runtime_memory: '$ONEAPP_ONEBE_RUNTIME_MEMORY'
+    oneapp_amqp_user: '$ONEAPP_AMQP_USER'
+    oneapp_amqp_pass: '$ONEAPP_AMQP_PASS'
+    oneapp_amqp_host: '$ONEAPP_AMQP_HOST'
+    oneapp_amqp_port: '$ONEAPP_AMQP_PORT'
+    oneapp_onebe_worker_processes: '$ONEAPP_ONEBE_WORKER_PROCESSES'
+    oneapp_onebe_runtime_timeout: '$ONEAPP_ONEBE_RUNTIME_TIMEOUT'
+    oneapp_onebe_max_workers: '$ONEAPP_ONEBE_MAX_WORKERS'
+    oneapp_onebe_min_workers: '$ONEAPP_ONEBE_MIN_WORKERS'
     token: 'YES'
     start_script_base64: "bWtkaXIgL21udC9jb250ZXh0Cm1vdW50IC9kZXYvY2Ryb20gL21udC9jb250ZXh0"
     ssh_public_key: "$USER[SSH_PUBLIC_KEY]"
@@ -69,4 +77,4 @@ opennebula_template:
     oneapp_onebe_autoscale: "0|text|Lithops backend autoscale option||all"
 logo: lithops.png
 disks:
-- "Service Lithops"
+- "Lithops"

--- a/appliances/LithopsService/01076f79-94be-4c8f-b57f-dec96d5d15a4.yaml
+++ b/appliances/LithopsService/01076f79-94be-4c8f-b57f-dec96d5d15a4.yaml
@@ -47,8 +47,6 @@ opennebula_template:
     oneapp_amqp_port: '$ONEAPP_AMQP_PORT'
     oneapp_onebe_worker_processes: '$ONEAPP_ONEBE_WORKER_PROCESSES'
     oneapp_onebe_runtime_timeout: '$ONEAPP_ONEBE_RUNTIME_TIMEOUT'
-    oneapp_onebe_max_workers: '$ONEAPP_ONEBE_MAX_WORKERS'
-    oneapp_onebe_min_workers: '$ONEAPP_ONEBE_MIN_WORKERS'
     token: 'YES'
     start_script_base64: "bWtkaXIgL21udC9jb250ZXh0Cm1vdW50IC9kZXYvY2Ryb20gL21udC9jb250ZXh0"
     ssh_public_key: "$USER[SSH_PUBLIC_KEY]"

--- a/appliances/LithopsService/32450c33-3e40-41a3-a9df-03a3f0a614c1.yaml
+++ b/appliances/LithopsService/32450c33-3e40-41a3-a9df-03a3f0a614c1.yaml
@@ -1,5 +1,5 @@
 ---
-name: Lithops Service - MinIO
+name: Lithops - MinIO
 version: 6.10.0-3-20250127
 publisher: OpenNebula Systems
 description: |-

--- a/appliances/LithopsService/651415b2-b890-4339-9ed6-ecd6c595321c.yaml
+++ b/appliances/LithopsService/651415b2-b890-4339-9ed6-ecd6c595321c.yaml
@@ -3,7 +3,7 @@ name: Lithops Service
 version: 6.10.0-3-20250513
 publisher: OpenNebula Systems
 description: |-
-  Lithops Service deployment using RabbitMQ as message broker, Lithops Workers as compute backend and MinIO as storage backend, 
+  Lithops Service deployment using RabbitMQ as message broker, Lithops Workers as compute backend and MinIO as storage backend,
   orchestrated by [OneFlow](https://docs.opennebula.io/stable/management_and_operations/multivm_service_management/appflow_elasticity.html)
 
   Requires

--- a/appliances/LithopsService/651415b2-b890-4339-9ed6-ecd6c595321c.yaml
+++ b/appliances/LithopsService/651415b2-b890-4339-9ed6-ecd6c595321c.yaml
@@ -58,8 +58,6 @@ opennebula_template:
         NAME = "NIC1",
         NETWORK_ID = "$Private"
       ]
-      ONEAPP_VROUTER_ETH0_VIP0 = "$ONEAPP_VROUTER_ETH0_VIP0"
-      ONEAPP_VROUTER_ETH1_VIP0 = "$ONEAPP_VROUTER_ETH1_VIP0"
       ONEAPP_VNF_HAPROXY_INTERFACES = "$ONEAPP_VNF_HAPROXY_INTERFACES"
       ONEAPP_VNF_HAPROXY_REFRESH_RATE = "$ONEAPP_VNF_HAPROXY_REFRESH_RATE"
       ONEAPP_VNF_DNS_ENABLED = "$ONEAPP_VNF_DNS_ENABLED"
@@ -68,7 +66,7 @@ opennebula_template:
       ONEAPP_VNF_NAT4_ENABLED = "$ONEAPP_VNF_NAT4_ENABLED"
       ONEAPP_VNF_NAT4_INTERFACES_OUT = "$ONEAPP_VNF_NAT4_INTERFACES_OUT"
       ONEAPP_VNF_ROUTER4_ENABLED = "$ONEAPP_VNF_ROUTER4_ENABLED"
-      ONEAPP_VNF_ROUTER4_INTERFACES = "$ONEAPP_VNF_ROUTER4_INTERFACES""
+      ONEAPP_VNF_ROUTER4_INTERFACES = "$ONEAPP_VNF_ROUTER4_INTERFACES"
     cooldown: 120
     elasticity_policies: []
     scheduled_policies: []
@@ -101,13 +99,11 @@ opennebula_template:
       ]
       FALLBACK_GW = "${vnf.TEMPLATE.CONTEXT.ETH1_IP}"
       FALLBACK_DNS = "${vnf.TEMPLATE.CONTEXT.ETH1_IP}"
-      ONEAPP_VROUTER_ETH0_VIP0 = "$ONEAPP_VROUTER_ETH0_VIP0"
-      ONEAPP_VROUTER_ETH1_VIP0 = "$ONEAPP_VROUTER_ETH1_VIP0"
       ONEAPP_AMQP_USER = "$ONEAPP_RABBITMQ_DEFAULT_USER"
       ONEAPP_AMQP_PASS = "$ONEAPP_RABBITMQ_DEFAULT_PASS"
       ONEAPP_AMQP_HOST = "${rabbitmq.TEMPLATE.CONTEXT.ETH0_IP}"
       ONEAPP_AMQP_PORT = "5672"
-      ONEAPP_VNF_DNS_ENABLED = "$ONEAPP_VNF_DNS_ENABLED""
+      ONEAPP_VNF_DNS_ENABLED = "$ONEAPP_VNF_DNS_ENABLED"
     cooldown: 120
     elasticity_policies: []
     scheduled_policies: []
@@ -125,7 +121,7 @@ opennebula_template:
       ONEAPP_MINIO_ROOT_USER="$ONEAPP_MINIO_ROOT_USER"
       ONEAPP_MINIO_ROOT_PASSWORD="$ONEAPP_MINIO_ROOT_PASSWORD"
       ONEAPP_MINIO_HOSTNAME="minio.opennebula.local"
-      ONEAPP_MINIO_TLS_ENABLED="NO""
+      ONEAPP_MINIO_TLS_ENABLED="NO"
     cooldown: 120
     elasticity_policies: []
     scheduled_policies: []
@@ -156,10 +152,8 @@ opennebula_template:
       ONEAPP_AMQP_PASS="$ONEAPP_RABBITMQ_DEFAULT_PASS"
       ONEAPP_AMQP_HOST="${rabbitmq.TEMPLATE.CONTEXT.ETH0_IP}"
       ONEAPP_AMQP_PORT="5672"
-      ONEAPP_ONEBE_WORKER_PROCESSES="${}"
-      ONEAPP_ONEBE_RUNTIME_TIMEOUT="${}"
-      ONEAPP_ONEBE_MAX_WORKERS="${}"
-      ONEAPP_ONEBE_MIN_WORKERS="${}"
+      ONEAPP_ONEBE_WORKER_PROCESSES="${lithops_worker.TEMPLATE.CPU}"
+      ONEAPP_ONEBE_RUNTIME_TIMEOUT="600"
     cooldown: 120
     elasticity_policies: []
     scheduled_policies: []
@@ -167,8 +161,6 @@ opennebula_template:
     Public: 'M|network|Public| |id::'
     Private: 'M|network|Private| |id::'
   custom_attrs:
-    ONEAPP_VROUTER_ETH0_VIP0: '0|text|Control Plane Endpoint VIP (IPv4)||'
-    ONEAPP_VROUTER_ETH1_VIP0: '0|text|Default Gateway VIP (IPv4)||'
     ONEAPP_STORAGE_DEVICE: '0|text|Storage device path||/dev/vdb'
     ONEAPP_STORAGE_FILESYSTEM: '0|text|Storage device filesystem||xfs'
     ONEAPP_VNF_HAPROXY_INTERFACES: '0|text|Interfaces to run Haproxy on||eth0'

--- a/appliances/LithopsService/651415b2-b890-4339-9ed6-ecd6c595321c.yaml
+++ b/appliances/LithopsService/651415b2-b890-4339-9ed6-ecd6c595321c.yaml
@@ -1,10 +1,10 @@
 ---
-name: Lithops Service Template
-version: 6.10.0-2-20241018
+name: Lithops Service
+version: 6.10.0-3-20250513
 publisher: OpenNebula Systems
 description: |-
-  Lithops Service deployment using OneKE as compute backend and MinIO as storage backend, orchestrated by
-  [OneFlow](https://docs.opennebula.io/stable/management_and_operations/multivm_service_management/appflow_elasticity.html)
+  Lithops Service deployment using RabbitMQ as message broker, Lithops Workers as compute backend and MinIO as storage backend, 
+  orchestrated by [OneFlow](https://docs.opennebula.io/stable/management_and_operations/multivm_service_management/appflow_elasticity.html)
 
   Requires
   [OneFlow](https://docs.opennebula.io/stable/management_and_operations/multivm_service_management/overview.html)
@@ -15,11 +15,12 @@ description: |-
   See the dedicated [documentation](https://github.com/OpenNebula/marketplace-community/wiki/lithops-service).
 
   Based on VM templates
-  - [Lithops-Service](/appliance/01076f79-94be-4c8f-b57f-dec96d5d15a4)
+  - [Lithops - Client](https://community-marketplace.opennebula.io/appliance/01076f79-94be-4c8f-b57f-dec96d5d15a4.yaml)
+  - [Lithops - Worker](https://community-marketplace.opennebula.io/appliance/8628d1b9-0868-469b-9edc-2384a898dddf.yaml)
+  - [Service Virtual Router](https://marketplace.opennebula.io/appliance/cc96d537-f6c7-499f-83f1-15ac4058750e)
   - [MinIO Multi-Node](32450c33-3e40-41a3-a9df-03a3f0a614c1)
-  - [OneKE 1.29 VNF](https://marketplace.opennebula.io/appliance/883d974f-f30e-4fc8-aa06-e1af2a020e49)
-  - [OneKE 1.29](https://marketplace.opennebula.io/appliance/d6278d1b-66a4-4188-acd0-e2628296046e)
-short_description: Multi-Node MinIO deployment for KVM hosts, orchestrated by OneFlow
+  - [RabbitMQ](https://community-marketplace.opennebula.io/appliance/c16c278c-464e-4b34-a77b-47208179dc76)
+short_description: Lithops deployment for KVM hosts, orchestrated by OneFlow
 tags:
 - lithops
 - computing
@@ -27,7 +28,7 @@ tags:
 - analytics
 - ubuntu
 - service
-creation_time: 1734631373
+creation_time: 1747149743
 os-id: Ubuntu
 os-release: '22.04 LTS'
 os-arch: x86_64
@@ -35,11 +36,11 @@ hypervisor: KVM
 opennebula_version: 6.8, 6.10
 type: 'SERVICE_TEMPLATE'
 roles:
-  vnf: 'OneKE 1.29 VNF'
-  master: 'OneKE 1.29'
-  worker: 'OneKE 1.29'
-  minio: 'Lithops Service - MinIO'
-  lithops: 'Lithops Service - Client'
+  vnf: 'Service Virtual Router'
+  minio: 'Lithops - MinIO'
+  lithops_client: 'Lithops - Client'
+  lithops_worker: 'Lithops - Worker'
+  rabbitmq: 'RabbitMQ'
 opennebula_template:
   name: Service Lithops
   deployment: straight
@@ -61,14 +62,6 @@ opennebula_template:
       ONEAPP_VROUTER_ETH1_VIP0 = "$ONEAPP_VROUTER_ETH1_VIP0"
       ONEAPP_VNF_HAPROXY_INTERFACES = "$ONEAPP_VNF_HAPROXY_INTERFACES"
       ONEAPP_VNF_HAPROXY_REFRESH_RATE = "$ONEAPP_VNF_HAPROXY_REFRESH_RATE"
-      ONEAPP_VNF_HAPROXY_LB0_IP = "<ETH0_EP0>"
-      ONEAPP_VNF_HAPROXY_LB0_PORT = "$ONEAPP_VNF_HAPROXY_LB0_PORT"
-      ONEAPP_VNF_HAPROXY_LB1_IP = "<ETH0_EP0>"
-      ONEAPP_VNF_HAPROXY_LB1_PORT = "$ONEAPP_VNF_HAPROXY_LB1_PORT"
-      ONEAPP_VNF_HAPROXY_LB2_IP = "<ETH0_EP0>"
-      ONEAPP_VNF_HAPROXY_LB2_PORT = "$ONEAPP_VNF_HAPROXY_LB2_PORT"
-      ONEAPP_VNF_HAPROXY_LB3_IP = "<ETH0_EP0>"
-      ONEAPP_VNF_HAPROXY_LB3_PORT = "$ONEAPP_VNF_HAPROXY_LB3_PORT"
       ONEAPP_VNF_DNS_ENABLED = "$ONEAPP_VNF_DNS_ENABLED"
       ONEAPP_VNF_DNS_INTERFACES = "$ONEAPP_VNF_DNS_INTERFACES"
       ONEAPP_VNF_DNS_NAMESERVERS = "$ONEAPP_VNF_DNS_NAMESERVERS"
@@ -79,7 +72,7 @@ opennebula_template:
     cooldown: 120
     elasticity_policies: []
     scheduled_policies: []
-  - name: master
+  - name: rabbitmq
     parents:
     - vnf
     cardinality: 1
@@ -91,32 +84,15 @@ opennebula_template:
       ]
       FALLBACK_GW = "${vnf.TEMPLATE.CONTEXT.ETH1_IP}"
       FALLBACK_DNS = "${vnf.TEMPLATE.CONTEXT.ETH1_IP}"
-      ONEAPP_VROUTER_ETH0_VIP0 = "$ONEAPP_VROUTER_ETH0_VIP0"
-      ONEAPP_VROUTER_ETH1_VIP0 = "$ONEAPP_VROUTER_ETH1_VIP0"
-      ONEAPP_RKE2_SUPERVISOR_EP = "$ONEAPP_RKE2_SUPERVISOR_EP"
-      ONEAPP_K8S_CONTROL_PLANE_EP = "$ONEAPP_K8S_CONTROL_PLANE_EP"
-      ONEAPP_K8S_EXTRA_SANS = "$ONEAPP_K8S_EXTRA_SANS"
-      ONEAPP_K8S_MULTUS_ENABLED = "$ONEAPP_K8S_MULTUS_ENABLED"
-      ONEAPP_K8S_MULTUS_CONFIG = "$ONEAPP_K8S_MULTUS_CONFIG"
-      ONEAPP_K8S_CNI_PLUGIN = "$ONEAPP_K8S_CNI_PLUGIN"
-      ONEAPP_K8S_CNI_CONFIG = "$ONEAPP_K8S_CNI_CONFIG"
-      ONEAPP_K8S_CILIUM_RANGE = "$ONEAPP_K8S_CILIUM_RANGE"
-      ONEAPP_K8S_LONGHORN_ENABLED = "$ONEAPP_K8S_LONGHORN_ENABLED"
-      ONEAPP_K8S_METALLB_ENABLED = "$ONEAPP_K8S_METALLB_ENABLED"
-      ONEAPP_K8S_METALLB_CONFIG = "$ONEAPP_K8S_METALLB_CONFIG"
-      ONEAPP_K8S_METALLB_RANGE = "$ONEAPP_K8S_METALLB_RANGE"
-      ONEAPP_K8S_TRAEFIK_ENABLED = "$ONEAPP_K8S_TRAEFIK_ENABLED"
-      ONEAPP_VNF_HAPROXY_LB0_IP = "<ETH0_EP0>"
-      ONEAPP_VNF_HAPROXY_LB0_PORT = "$ONEAPP_VNF_HAPROXY_LB0_PORT"
-      ONEAPP_VNF_HAPROXY_LB1_IP = "<ETH0_EP0>"
-      ONEAPP_VNF_HAPROXY_LB1_PORT = "$ONEAPP_VNF_HAPROXY_LB1_PORT"
-      ONEAPP_VNF_DNS_ENABLED = "$ONEAPP_VNF_DNS_ENABLED""
+      ONEAPP_RABBITMQ_DEFAULT_USER = "$ONEAPP_RABBITMQ_DEFAULT_USER"
+      ONEAPP_RABBITMQ_DEFAULT_PASS = "$ONEAPP_RABBITMQ_DEFAULT_PASS"
     cooldown: 120
     elasticity_policies: []
     scheduled_policies: []
-  - name: worker
+  - name: lithops_worker
     parents:
     - vnf
+    - rabbitmq
     cardinality: 1
     vm_template_contents: |
       NIC = [
@@ -127,19 +103,10 @@ opennebula_template:
       FALLBACK_DNS = "${vnf.TEMPLATE.CONTEXT.ETH1_IP}"
       ONEAPP_VROUTER_ETH0_VIP0 = "$ONEAPP_VROUTER_ETH0_VIP0"
       ONEAPP_VROUTER_ETH1_VIP0 = "$ONEAPP_VROUTER_ETH1_VIP0"
-      ONEAPP_RKE2_SUPERVISOR_EP = "$ONEAPP_RKE2_SUPERVISOR_EP"
-      ONEAPP_K8S_CONTROL_PLANE_EP = "$ONEAPP_K8S_CONTROL_PLANE_EP"
-      ONEAPP_K8S_MULTUS_ENABLED = "$ONEAPP_K8S_MULTUS_ENABLED"
-      ONEAPP_K8S_CNI_PLUGIN = "$ONEAPP_K8S_CNI_PLUGIN"
-      ONEAPP_K8S_LONGHORN_ENABLED = "$ONEAPP_K8S_LONGHORN_ENABLED"
-      ONEAPP_K8S_METALLB_ENABLED = "$ONEAPP_K8S_METALLB_ENABLED"
-      ONEAPP_K8S_TRAEFIK_ENABLED = "$ONEAPP_K8S_TRAEFIK_ENABLED"
-      ONEAPP_VNF_HAPROXY_LB0_PORT = "$ONEAPP_VNF_HAPROXY_LB0_PORT"
-      ONEAPP_VNF_HAPROXY_LB1_PORT = "$ONEAPP_VNF_HAPROXY_LB1_PORT"
-      ONEAPP_VNF_HAPROXY_LB2_IP = "<ETH0_EP0>"
-      ONEAPP_VNF_HAPROXY_LB2_PORT = "$ONEAPP_VNF_HAPROXY_LB2_PORT"
-      ONEAPP_VNF_HAPROXY_LB3_IP = "<ETH0_EP0>"
-      ONEAPP_VNF_HAPROXY_LB3_PORT = "$ONEAPP_VNF_HAPROXY_LB3_PORT"
+      ONEAPP_AMQP_USER = "$ONEAPP_RABBITMQ_DEFAULT_USER"
+      ONEAPP_AMQP_PASS = "$ONEAPP_RABBITMQ_DEFAULT_PASS"
+      ONEAPP_AMQP_HOST = "${rabbitmq.TEMPLATE.CONTEXT.ETH0_IP}"
+      ONEAPP_AMQP_PORT = "5672"
       ONEAPP_VNF_DNS_ENABLED = "$ONEAPP_VNF_DNS_ENABLED""
     cooldown: 120
     elasticity_policies: []
@@ -165,7 +132,7 @@ opennebula_template:
   - name: lithops
     parents:
     - vnf
-    - master
+    - rabbitmq
     - minio
     cardinality: 1
     vm_template_contents: |
@@ -175,7 +142,7 @@ opennebula_template:
       ]
       FALLBACK_GW = "${vnf.TEMPLATE.CONTEXT.ETH1_IP}"
       FALLBACK_DNS = "${vnf.TEMPLATE.CONTEXT.ETH1_IP}"
-      ONEAPP_LITHOPS_BACKEND="one"
+      ONEAPP_LITHOPS_BACKEND="amqp"
       ONEAPP_LITHOPS_STORAGE="minio"
       ONEAPP_MINIO_ENDPOINT="http://${minio.TEMPLATE.CONTEXT.ETH0_IP}:9000"
       ONEAPP_MINIO_ACCESS_KEY_ID="$ONEAPP_MINIO_ROOT_USER"
@@ -183,8 +150,16 @@ opennebula_template:
       ONEAPP_ONEBE_DOCKER_USER="$ONEAPP_ONEBE_DOCKER_USER"
       ONEAPP_ONEBE_DOCKER_PASSWORD="$ONEAPP_ONEBE_DOCKER_PASSWORD"
       ONEAPP_ONEBE_AUTOSCALE="$ONEAPP_ONEBE_AUTOSCALE"
-      ONEAPP_ONEBE_RUNTIME_CPU="${worker.TEMPLATE.CPU}"
-      ONEAPP_ONEBE_RUNTIME_MEMORY="${worker.TEMPLATE.MEMORY}""
+      ONEAPP_ONEBE_RUNTIME_CPU="${lithops_worker.TEMPLATE.CPU}"
+      ONEAPP_ONEBE_RUNTIME_MEMORY="${lithops_worker.TEMPLATE.MEMORY}"
+      ONEAPP_AMQP_USER="$ONEAPP_RABBITMQ_DEFAULT_USER"
+      ONEAPP_AMQP_PASS="$ONEAPP_RABBITMQ_DEFAULT_PASS"
+      ONEAPP_AMQP_HOST="${rabbitmq.TEMPLATE.CONTEXT.ETH0_IP}"
+      ONEAPP_AMQP_PORT="5672"
+      ONEAPP_ONEBE_WORKER_PROCESSES="${}"
+      ONEAPP_ONEBE_RUNTIME_TIMEOUT="${}"
+      ONEAPP_ONEBE_MAX_WORKERS="${}"
+      ONEAPP_ONEBE_MIN_WORKERS="${}"
     cooldown: 120
     elasticity_policies: []
     scheduled_policies: []
@@ -194,27 +169,10 @@ opennebula_template:
   custom_attrs:
     ONEAPP_VROUTER_ETH0_VIP0: '0|text|Control Plane Endpoint VIP (IPv4)||'
     ONEAPP_VROUTER_ETH1_VIP0: '0|text|Default Gateway VIP (IPv4)||'
-    ONEAPP_RKE2_SUPERVISOR_EP: '0|text|RKE2 Supervisor endpoint||ep0.eth0.vr:9345'
-    ONEAPP_K8S_CONTROL_PLANE_EP: '0|text|Control Plane endpoint||ep0.eth0.vr:6443'
-    ONEAPP_K8S_EXTRA_SANS: '0|text|ApiServer extra certificate SANs||localhost,127.0.0.1,ep0.eth0.vr,${vnf.TEMPLATE.CONTEXT.ETH0_IP}'
-    ONEAPP_K8S_MULTUS_ENABLED: '0|boolean|Enable Multus||NO'
-    ONEAPP_K8S_MULTUS_CONFIG: '0|text64|Multus custom config (default none)||'
-    ONEAPP_K8S_CNI_PLUGIN: '0|list|CNI plugin supported by RKE2|canal,calico,cilium|cilium'
-    ONEAPP_K8S_CNI_CONFIG: '0|text64|CNI custom config (default none)||'
-    ONEAPP_K8S_CILIUM_RANGE: '0|text|Cilium LB IP CIDR (default none)||'
-    ONEAPP_K8S_METALLB_ENABLED: '0|boolean|Enable MetalLB||NO'
-    ONEAPP_K8S_METALLB_RANGE: '0|text|MetalLB IP range (default none)||'
-    ONEAPP_K8S_METALLB_CONFIG: '0|text64|MetalLB custom config (default none)||'
-    ONEAPP_K8S_LONGHORN_ENABLED: '0|boolean|Enable Longhorn||NO'
     ONEAPP_STORAGE_DEVICE: '0|text|Storage device path||/dev/vdb'
     ONEAPP_STORAGE_FILESYSTEM: '0|text|Storage device filesystem||xfs'
-    ONEAPP_K8S_TRAEFIK_ENABLED: '0|boolean|Enable Traefik||NO'
     ONEAPP_VNF_HAPROXY_INTERFACES: '0|text|Interfaces to run Haproxy on||eth0'
     ONEAPP_VNF_HAPROXY_REFRESH_RATE: '0|number|Haproxy refresh rate||30'
-    ONEAPP_VNF_HAPROXY_LB0_PORT: '0|number|HTTPS RKE2 Supervisor port||9345'
-    ONEAPP_VNF_HAPROXY_LB1_PORT: '0|number|HTTPS API Server port||6443'
-    ONEAPP_VNF_HAPROXY_LB2_PORT: '0|number|HTTPS ingress port||443'
-    ONEAPP_VNF_HAPROXY_LB3_PORT: '0|number|HTTP ingress port||80'
     ONEAPP_VNF_DNS_ENABLED: '0|boolean|Enable DNS recursor||YES'
     ONEAPP_VNF_DNS_INTERFACES: '0|text|DNS - Interfaces||eth1'
     ONEAPP_VNF_DNS_NAMESERVERS: '0|text|DNS - Nameservers||1.1.1.1,8.8.8.8'
@@ -228,6 +186,8 @@ opennebula_template:
     ONEAPP_ONEBE_DOCKER_PASSWORD: 'M|password|Docker user password for Lithops||'
     ONEAPP_ONEBE_JUPYTER_PASSWORD: 'M|password|Password for Jupyter access||'
     ONEAPP_ONEBE_AUTOSCALE: '0|text|Lithops backend autoscale option||all'
+    ONEAPP_RABBITMQ_DEFAULT_USER: 'M|text|RabbitMQ User||oneadmin'
+    ONEAPP_RABBITMQ_DEFAULT_PASS: 'M|password|RabbitMQ User Password||'
   ready_status_gate: true
 logo: lithops.png
 images: []

--- a/appliances/LithopsService/651415b2-b890-4339-9ed6-ecd6c595321c.yaml
+++ b/appliances/LithopsService/651415b2-b890-4339-9ed6-ecd6c595321c.yaml
@@ -130,6 +130,7 @@ opennebula_template:
     - vnf
     - rabbitmq
     - minio
+    - lithops_worker
     cardinality: 1
     vm_template_contents: |
       NIC = [

--- a/appliances/LithopsService/8628d1b9-0868-469b-9edc-2384a898dddf.yaml
+++ b/appliances/LithopsService/8628d1b9-0868-469b-9edc-2384a898dddf.yaml
@@ -1,0 +1,55 @@
+---
+name: Lithops - Worker
+version: 6.10.0-3-20250513
+publisher: OpenNebula Systems
+description: |-
+  [Lithops](https://lithops-cloud.github.io/docs/) Worker Appliance for Lithops compute backend.
+  It requires a RabbitMQ message broker.
+
+  See the dedicated [documentation](https://github.com/OpenNebula/marketplace-community/wiki/lithops_intro).
+short_description: Appliance with preinstalled Lithops Worker for KVM hosts
+tags:
+- lithops
+- ubuntu
+- service
+format: qcow2
+creation_time: 1747149743
+os-id: Ubuntu
+os-release: 22.04 LTS
+os-arch: x86_64
+hypervisor: KVM
+opennebula_version: 6.8, 6.10
+opennebula_template:
+  context:
+    network: 'YES'
+    oneapp_amqp_user: '$ONEAPP_AMQP_USER'
+    oneapp_amqp_pass: '$ONEAPP_AMQP_PASS'
+    oneapp_amqp_host: '$ONEAPP_AMQP_HOST'
+    oneapp_amqp_port: '$ONEAPP_AMQP_PORT'
+    ssh_public_key: "$USER[SSH_PUBLIC_KEY]"
+  cpu: '1'
+  graphics:
+    listen: 0.0.0.0
+    type: vnc
+  inputs_order: >-
+    ONEAPP_AMQP_URL
+  memory: '768'
+  os:
+    arch: x86_64
+  user_inputs:
+    oneapp_amqp_user: O|text|AMQP Queue user| |
+    oneapp_amqp_pass: O|password|AMQP Queue password| |
+    oneapp_amqp_host: M|text|AMQP Queue host| |127.0.0.1
+    oneapp_amqp_port: M|text|AMQP Queue port| |5672
+logo: lithops.png
+images:
+- name: service_Lithops_Worker
+  url: >-
+    https://opennebula-community-marketplace.s3.eu-west-1.amazonaws.com/service_Lithops_Worker-6.10.0-3-20250513.qcow2
+  type: OS
+  dev_prefix: vd
+  driver: qcow2
+  size: 5242880000
+  checksum:
+    md5: 3927edf94befbc02ae6a49f7e6750ed8
+    sha256: 81f2b3ee09ead33d392e361b759c39fbe727316b1c562b06ff95b5581db176ea

--- a/appliances/LithopsService/8628d1b9-0868-469b-9edc-2384a898dddf.yaml
+++ b/appliances/LithopsService/8628d1b9-0868-469b-9edc-2384a898dddf.yaml
@@ -45,7 +45,7 @@ logo: lithops.png
 images:
 - name: service_Lithops_Worker
   url: >-
-    https://opennebula-community-marketplace.s3.eu-west-1.amazonaws.com/service_Lithops_Worker-6.10.0-3-20250513.qcow2
+    https://d38nm155miqkyg.cloudfront.net/service_Lithops_Worker-6.10.0-3-20250513.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2

--- a/appliances/service/695ab19e-23dc-11ef-a2b8-59beec9fdf86.yaml
+++ b/appliances/service/695ab19e-23dc-11ef-a2b8-59beec9fdf86.yaml
@@ -1,9 +1,9 @@
 ---
-name: Service Lithops
-version: 6.10.0-3-20250128
+name: Lithops
+version: 6.10.0-3-20250513
 publisher: OpenNebula Systems
 description: |-
-  Appliance with preinstalled [Lithops](https://lithops-cloud.github.io/docs/) and Docker for k8s backend.
+  Appliance with preinstalled [Lithops](https://lithops-cloud.github.io/docs/) and Docker.
 
   See the dedicated [documentation](https://github.com/OpenNebula/marketplace-community/wiki/lithops_quick).
 short_description: Appliance with preinstalled Lithops for KVM hosts
@@ -12,7 +12,7 @@ tags:
 - ubuntu
 - service
 format: qcow2
-creation_time: 1717672311
+creation_time: 1747149743
 os-id: Ubuntu
 os-release: 22.04 LTS
 os-arch: x86_64
@@ -50,11 +50,11 @@ logo: lithops.png
 images:
 - name: service_Lithops
   url: >-
-    https://d24fmfybwxpuhu.cloudfront.net/service_Lithops-6.10.0-3-20250128.qcow2
+    https://opennebula-community-marketplace.s3.eu-west-1.amazonaws.com/service_Lithops-6.10.0-3-20250513.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2
   size: 5242880000
   checksum:
-    md5: 70988b51e32a32897c2537f20c10433f
-    sha256: e75317ccf0019908fba93cb17fb77afd7c5ab74695c994b5d22d9356e75a6871
+    md5: 5a2836f94361200f4a74e36cf56b7429
+    sha256: 90de590ea070c33809924ad85bfab59e299a50328a2c19c89bb937569d8e65d2

--- a/appliances/service/695ab19e-23dc-11ef-a2b8-59beec9fdf86.yaml
+++ b/appliances/service/695ab19e-23dc-11ef-a2b8-59beec9fdf86.yaml
@@ -50,7 +50,7 @@ logo: lithops.png
 images:
 - name: service_Lithops
   url: >-
-    https://opennebula-community-marketplace.s3.eu-west-1.amazonaws.com/service_Lithops-6.10.0-3-20250513.qcow2
+    https://d38nm155miqkyg.cloudfront.net/service_Lithops-6.10.0-3-20250513.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2

--- a/appliances/service/c16c278c-464e-4b34-a77b-47208179dc76.yaml
+++ b/appliances/service/c16c278c-464e-4b34-a77b-47208179dc76.yaml
@@ -36,7 +36,7 @@ logo: rabbitmq.png
 images:
 - name: service_rabbitmq
   url: >-
-    https://opennebula-community-marketplace.s3.eu-west-1.amazonaws.com/service_rabbitmq-6.10.0-3-20250331.qcow2
+    https://d38nm155miqkyg.cloudfront.net/service_rabbitmq-6.10.0-3-20250331.qcow2
   type: OS
   dev_prefix: vd
   driver: qcow2

--- a/apps-code/community-apps/Makefile.config
+++ b/apps-code/community-apps/Makefile.config
@@ -7,7 +7,7 @@ VERBOSE         := 1
 PACKER_LOG      := 0
 PACKER_HEADLESS := true
 
-SERVICES := service_Lithops service_rabbitmq service_UERANSIM capone131 service_example
+SERVICES := service_Lithops service_Lithops_Worker service_rabbitmq service_UERANSIM capone131 service_example
 
 .DEFAULT_GOAL := help
 

--- a/apps-code/community-apps/appliances/Lithops/appliance.sh
+++ b/apps-code/community-apps/appliances/Lithops/appliance.sh
@@ -28,19 +28,28 @@ ONE_SERVICE_PARAMS=(
     'ONEAPP_MINIO_ENDPOINT_CERT'        'configure'  'Lithops storage backend MinIO endpoint certificate'               'O|text64'
     'ONEAPP_ONEBE_DOCKER_USER'          'configure'  'Username from dockerhub'                                          'O|text'
     'ONEAPP_ONEBE_DOCKER_PASSWORD'      'configure'  'Password for dockerhub'                                           'O|password'
-    'ONEAPP_ONEBE_RUNTIME_CPU'          'configure'  'Number of vCPU per POD'                                           'O|text'
-    'ONEAPP_ONEBE_RUNTIME_MEMORY'       'configure'  'Amount of memory per POD'                                         'O|text'
+    'ONEAPP_ONEBE_RUNTIME_CPU'          'configure'  'Number of vCPU per ONEBE'                                         'O|text'
+    'ONEAPP_ONEBE_RUNTIME_MEMORY'       'configure'  'Amount of memory per ONEBE'                                       'O|text'
     'ONEAPP_ONEBE_KUBECFG_PATH'         'configure'  'Path where kubeconfig file will be stored'                        'O|text'
     'ONEAPP_ONEBE_AUTOSCALE'            'configure'  'k8s backend autoscale option'                                     'O|text'
     'FALLBACK_GW'                       'configure'  'Appliance GW for Service mode'                                    'O|text'
     'FALLBACK_DNS'                      'configure'  'Appliance DNS for Service mode'                                   'O|text'
+    'ONEAPP_AMQP_USER'                  'configure'  'AMQP broker username'                                             'O|text'
+    'ONEAPP_AMQP_PASS'                  'configure'  'AMQP broker password'                                             'O|password'
+    'ONEAPP_AMQP_HOST'                  'configure'  'AMQP broker host'                                                 'O|text'
+    'ONEAPP_AMQP_PORT'                  'configure'  'AMQP broker port'                                                 'O|text'
+    'ONEAPP_ONEBE_WORKER_PROCESSES'     'configure'  'Number of worker processes for ONEBE'                             'O|text'
+    'ONEAPP_ONEBE_RUNTIME_TIMEOUT'      'configure'  'Runtime timeout in seconds'                                       'O|text'
+    'ONEAPP_ONEBE_MAX_WORKERS'          'configure'  'Maximum number of ONEBE workers'                                  'O|text'
+    'ONEAPP_ONEBE_MIN_WORKERS'          'configure'  'Minimum number of ONEBE workers'                                  'O|text'
 )
+
 
 
 ### Appliance metadata ###############################################
 
 # Appliance metadata
-ONE_SERVICE_NAME='Service Lithops - KVM'
+ONE_SERVICE_NAME='Lithops'
 ONE_SERVICE_VERSION='3.4.0'   #latest
 ONE_SERVICE_BUILD=$(date +%s)
 ONE_SERVICE_SHORT_DESCRIPTION='Appliance with preinstalled Lithops for KVM hosts'
@@ -48,6 +57,9 @@ ONE_SERVICE_DESCRIPTION=$(cat <<EOF
 Appliance with preinstalled Lithops v3.4.0.
 
 By default, it uses localhost both for Compute and Storage Backend.
+
+- Compute options: localhost, one, amqp
+- Storage options: localhost, minio
 
 To configure MinIO as Storage Backend use the parameter ONEAPP_LITHOPS_STORAGE=minio
 with ONEAPP_MINIO_ENDPOINT, ONEAPP_MINIO_ACCESS_KEY_ID and ONEAPP_MINIO_SECRET_ACCESS_KEY.
@@ -72,6 +84,14 @@ ONEAPP_ONEBE_RUNTIME_CPU="${ONEAPP_ONEBE_RUNTIME_CPU:-1}"
 ONEAPP_ONEBE_RUNTIME_MEMORY="${ONEAPP_ONEBE_RUNTIME_MEMORY:-512}"
 ONEAPP_ONEBE_KUBECFG_PATH="${ONEAPP_ONEBE_KUBECFG_PATH:-\/tmp\/kubeconfig}"
 ONEAPP_ONEBE_AUTOSCALE="${ONEAPP_ONEBE_AUTOSCALE:-all}"
+ONEAPP_AMQP_USER="${ONEAPP_AMQP_USER:-}"
+ONEAPP_AMQP_PASS="${ONEAPP_AMQP_PASS:-}"
+ONEAPP_AMQP_HOST="${ONEAPP_AMQP_HOST:-127.0.0.1}"
+ONEAPP_AMQP_PORT="${ONEAPP_AMQP_PORT:-5672}"
+ONEAPP_ONEBE_WORKER_PROCESSES="${ONEAPP_ONEBE_WORKER_PROCESSES:-2}"
+ONEAPP_ONEBE_RUNTIME_TIMEOUT="${ONEAPP_ONEBE_RUNTIME_TIMEOUT:-600}"
+ONEAPP_ONEBE_MAX_WORKERS="${ONEAPP_ONEBE_MAX_WORKERS:-3}"
+ONEAPP_ONEBE_MIN_WORKERS="${ONEAPP_ONEBE_MIN_WORKERS:-1}"
 
 ### Globals ##########################################################
 
@@ -269,6 +289,9 @@ lithops:
 
 # Start Storage Backend configuration
 # End Storage Backend configuration
+
+# Start Monitoring configuration
+# End Monitoring configuration
 EOF
 }
 
@@ -298,6 +321,33 @@ update_lithops_config(){
             msg info "runtime_memory: ${ONEAPP_ONEBE_RUNTIME_MEMORY}; runtime_cpu: ${ONEAPP_ONEBE_RUNTIME_CPU}"
             sed -i -ne "/# Start Compute/ {p; ione:\n  docker_user: ${ONEAPP_ONEBE_DOCKER_USER}\n  docker_password: ${ONEAPP_ONEBE_DOCKER_PASSWORD}\n  runtime_cpu: ${ONEAPP_ONEBE_RUNTIME_CPU}\n  runtime_memory: ${ONEAPP_ONEBE_RUNTIME_MEMORY}\n  kubecfg_path: ${ONEAPP_ONEBE_KUBECFG_PATH}\n  auto_scale: ${ONEAPP_ONEBE_AUTOSCALE}" -e ":a; n; /# End Compute/ {p; b}; ba}; p" /etc/lithops/config
         fi
+    elif [[ ${ONEAPP_LITHOPS_BACKEND} = "amqp" ]]; then
+        msg info "Edit config file for AMQP Compute Backend"
+        if ! check_amqpbe_attrs; then
+            msg info "Check AMQP backend attributes"
+            msg error "AMQP backend configuration failed"
+            exit 1
+        else
+            
+            if [[ -n "$ONEAPP_AMQP_USER" && -n "$ONEAPP_AMQP_PASS" ]]; then
+                ONEAPP_AMQP_URL="amqp://${ONEAPP_AMQP_USER}:${ONEAPP_AMQP_PASS}@${ONEAPP_AMQP_HOST}:${ONEAPP_AMQP_PORT}/"
+            else
+                ONEAPP_AMQP_URL="amqp://${ONEAPP_AMQP_HOST}:${ONEAPP_AMQP_PORT}/"
+            fi
+
+            msg info "Adding AMQP backend configuration to /etc/lithops/config"
+            sed -i '/^lithops:/a\  monitoring: rabbitmq' /etc/lithops/config
+
+            sed -i -ne "/# Start Compute/ {
+            p;
+            ione:\n  worker_processes: ${ONEAPP_ONEBE_WORKER_PROCESSES}\n  runtime_memory: ${ONEAPP_ONEBE_RUNTIME_MEMORY}\n  runtime_timeout: ${ONEAPP_ONEBE_RUNTIME_TIMEOUT}\n  runtime_cpu: ${ONEAPP_ONEBE_RUNTIME_CPU}\n  amqp_url: ${ONEAPP_AMQP_URL}\n  max_workers: ${ONEAPP_ONEBE_MAX_WORKERS}\n  min_workers: ${ONEAPP_ONEBE_MIN_WORKERS}\n  autoscale: ${ONEAPP_ONEBE_AUTOSCALE}
+            }" -e ":a; n; /# End Compute/ {p; b}; ba; p" /etc/lithops/config
+
+            sed -i -ne "/# Start Monitoring/ {
+            p;
+            irabbitmq:\n  amqp_url: ${ONEAPP_AMQP_URL}
+            }" -e ":a; n; /# End Monitoring/ {p; b}; ba; p" /etc/lithops/config
+        fi 
     fi
 
     if [[ ${ONEAPP_LITHOPS_STORAGE} = "localhost" ]]; then
@@ -330,6 +380,13 @@ check_onebe_attrs()
 {
     [[ -z "$ONEAPP_ONEBE_DOCKER_USER" ]] && return 1
     [[ -z "$ONEAPP_ONEBE_DOCKER_PASSWORD" ]] && return 1
+    return 0
+}
+
+check_amqpbe_attrs()
+{
+    [[ -z "$ONEAPP_AMQP_HOST" ]] && return 1
+    [[ -z "$ONEAPP_AMQP_PORT" ]] && return 1
     return 0
 }
 

--- a/apps-code/community-apps/appliances/Lithops_Worker/appliance.sh
+++ b/apps-code/community-apps/appliances/Lithops_Worker/appliance.sh
@@ -1,0 +1,187 @@
+# ---------------------------------------------------------------------------- #
+# Copyright 2024, OpenNebula Project, OpenNebula Systems                  #
+#                                                                              #
+# Licensed under the Apache License, Version 2.0 (the "License"); you may      #
+# not use this file except in compliance with the License. You may obtain      #
+# a copy of the License at                                                     #
+#                                                                              #
+# http://www.apache.org/licenses/LICENSE-2.0                                   #
+#                                                                              #
+# Unless required by applicable law or agreed to in writing, software          #
+# distributed under the License is distributed on an "AS IS" BASIS,            #
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.     #
+# See the License for the specific language governing permissions and          #
+# limitations under the License.                                               #
+# ---------------------------------------------------------------------------- #
+set -o errexit -o pipefail
+
+
+# List of contextualization parameters
+ONE_SERVICE_PARAMS=(
+    'ONEAPP_AMQP_URL'                  'configure'  'AMQP URL for message broker'                                      'O|text'
+)
+
+
+### Appliance metadata ###############################################
+
+# Appliance metadata
+ONE_SERVICE_NAME='Lithops - Worker'
+ONE_SERVICE_VERSION='3.4.0'   #latest
+ONE_SERVICE_BUILD=$(date +%s)
+ONE_SERVICE_SHORT_DESCRIPTION='Appliance with preinstalled Lithops Worker for Lithops compute backend'
+ONE_SERVICE_DESCRIPTION=$(cat <<EOF
+Appliance with preinstalled Lithops Worker for Lithops Service.
+
+This service connects to a RabbitMQ broker and listens for execution requests
+sent by the Lithops client. Upon receiving a request, it will deserialize and
+run the specified function, then return the result through the messaging system.
+
+The connection to the message broker is configured via the AMQP_URL that will be constructed based on 
+user imput parameter, becoming an AMQP URI (e.g. amqp://user:pass@host:5672/).
+
+This worker appliance must be co-deployed with a compatible Lithops client and RabbitMQ
+service in the same network.
+
+Logs are written to /var/log/lithops.log.
+EOF
+)
+ONE_SERVICE_RECONFIGURABLE=true
+
+### Contextualization defaults #######################################
+ONEAPP_AMQP_USER="${ONEAPP_AMQP_USER:-}"
+ONEAPP_AMQP_PASS="${ONEAPP_AMQP_PASS:-}"
+ONEAPP_AMQP_HOST="${ONEAPP_AMQP_HOST:-127.0.0.1}"
+ONEAPP_AMQP_PORT="${ONEAPP_AMQP_PORT:-5672}"
+
+### Globals ##########################################################
+
+LITHOPS_REPO="https://github.com/OpenNebula/lithops.git"
+LITHOPS_BRANCH="f-569"
+
+###############################################################################
+###############################################################################
+###############################################################################
+
+#
+# service implementation
+#
+
+service_cleanup()
+{
+    :
+}
+
+service_install()
+{
+
+    install_system_dependencies
+    clone_lithops_repository
+    create_virtualenv
+    install_python_dependencies
+
+    msg info "INSTALLATION FINISHED"
+
+    return 0
+}
+
+service_configure()
+{
+    setup_service
+    mount_onegate
+    return 0
+}
+
+service_bootstrap()
+{
+    return 0
+}
+
+###############################################################################
+###############################################################################
+###############################################################################
+
+#
+# functions
+#
+
+install_system_dependencies() {
+    echo "=== Updating apt repositories and installing system dependencies ==="
+    apt-get update && apt-get install -y \
+        build-essential \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        git \
+        zip && \
+    rm -rf /var/lib/apt/lists/*
+}
+
+mount_onegate() {
+    mkdir /mnt/context
+    mount /dev/cdrom /mnt/context
+}
+
+clone_lithops_repository() {
+    echo "=== Cloning the Lithops repository into /lithops ==="
+    git clone --single-branch --branch ${LITHOPS_BRANCH} ${LITHOPS_REPO} /lithops
+}
+
+create_virtualenv() {
+    echo "=== Creating a Python virtual environment in /lithops-venv ==="
+    python3 -m venv /lithops-venv
+}
+
+install_python_dependencies() {
+    echo "=== Upgrading pip, setuptools, and six; Installing Python dependencies ==="
+    source /lithops-venv/bin/activate
+    pip install --upgrade setuptools six pip
+    pip install --no-cache-dir \
+        boto3 \
+        pika \
+        flask \
+        gevent \
+        redis \
+        requests \
+        PyYAML \
+        numpy \
+        cloudpickle \
+        ps-mem \
+        tblib \
+        psutil
+}
+
+setup_service() {
+    echo "=== Copying entry_point.py to / ==="
+    cp /lithops/lithops/serverless/backends/one/entry_point.py /entry_point.py
+
+    if [[ -n "$ONEAPP_AMQP_USER" && -n "$ONEAPP_AMQP_PASS" ]]; then
+        ONEAPP_AMQP_URL="amqp://${ONEAPP_AMQP_USER}:${ONEAPP_AMQP_PASS}@${ONEAPP_AMQP_HOST}:${ONEAPP_AMQP_PORT}/"
+    else
+        ONEAPP_AMQP_URL="amqp://${ONEAPP_AMQP_HOST}:${ONEAPP_AMQP_PORT}/"
+    fi
+
+    echo "=== Creating systemd service file ==="
+    cat <<EOF > /etc/systemd/system/lithops.service
+[Unit]
+Description=Lithops Entry Point
+After=network.target
+
+[Service]
+User=root
+Group=root
+WorkingDirectory=/
+ExecStart=/lithops-venv/bin/python /entry_point.py ${ONEAPP_AMQP_URL}
+Restart=always
+RestartSec=5
+StandardOutput=append:/var/log/lithops.log
+StandardError=append:/var/log/lithops.log
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+    echo "=== Reloading systemd, enabling, and starting the service ==="
+    systemctl daemon-reload
+    systemctl enable lithops
+    systemctl start lithops
+}

--- a/apps-code/community-apps/packer/service_Lithops_Worker/81-configure-ssh.sh
+++ b/apps-code/community-apps/packer/service_Lithops_Worker/81-configure-ssh.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Configures critical settings for OpenSSH server.
+
+exec 1>&2
+set -eux -o pipefail
+
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "PasswordAuthentication no" }
+/^[#\s]*PasswordAuthentication\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "PermitRootLogin without-password" }
+/^[#\s]*PermitRootLogin\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "UseDNS no" }
+/^[#\s]*UseDNS\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+sync

--- a/apps-code/community-apps/packer/service_Lithops_Worker/82-configure-context.sh
+++ b/apps-code/community-apps/packer/service_Lithops_Worker/82-configure-context.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Configure and enable service context.
+
+exec 1>&2
+set -eux -o pipefail
+
+mv /etc/one-appliance/net-90-service-appliance /etc/one-context.d/
+mv /etc/one-appliance/net-99-report-ready      /etc/one-context.d/
+
+chown root:root /etc/one-context.d/*
+chmod u=rwx,go=rx /etc/one-context.d/*
+
+sync

--- a/apps-code/community-apps/packer/service_Lithops_Worker/Lithops.pkr.hcl
+++ b/apps-code/community-apps/packer/service_Lithops_Worker/Lithops.pkr.hcl
@@ -1,0 +1,107 @@
+source "null" "null" { communicator = "none" }
+
+build {
+  sources = ["source.null.null"]
+
+  provisioner "shell-local" {
+    inline = [
+      "mkdir -p ${var.input_dir}/context",
+      "${var.input_dir}/gen_context > ${var.input_dir}/context/context.sh",
+      "mkisofs -o ${var.input_dir}/${var.appliance_name}-context.iso -V CONTEXT -J -R ${var.input_dir}/context",
+    ]
+  }
+}
+
+# Build VM image
+source "qemu" "Lithops" {
+  cpus        = 2
+  memory      = 2048
+  accelerator = "kvm"
+
+  iso_url      = "../one-apps/export/ubuntu2204.qcow2"
+  iso_checksum = "none"
+
+  headless = var.headless
+
+  disk_image       = true
+  disk_cache       = "unsafe"
+  disk_interface   = "virtio"
+  net_device       = "virtio-net"
+  format           = "qcow2"
+  disk_compression = false
+  disk_size        = "5000"
+
+  output_directory = var.output_dir
+
+  qemuargs = [
+    ["-cpu", "host"],
+    ["-cdrom", "${var.input_dir}/${var.appliance_name}-context.iso"],
+    ["-serial", "stdio"],
+    # MAC addr needs to mach ETH0_MAC from context iso
+    ["-netdev", "user,id=net0,hostfwd=tcp::{{ .SSHHostPort }}-:22"],
+    ["-device", "virtio-net-pci,netdev=net0,mac=00:11:22:33:44:55"]
+  ]
+  ssh_username     = "root"
+  ssh_password     = "opennebula"
+  ssh_timeout      = "900s"
+  shutdown_command = "poweroff"
+  vm_name          = "${var.appliance_name}"
+}
+
+build {
+  sources = ["source.qemu.Lithops"]
+
+  # revert insecure ssh options done by context start_script
+  provisioner "shell" {
+    scripts = ["${var.input_dir}/81-configure-ssh.sh"]
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -e"
+    inline = [
+      "install -o 0 -g 0 -m u=rwx,g=rx,o=   -d /etc/one-appliance/{,service.d/,lib/}",
+      "install -o 0 -g 0 -m u=rwx,g=rx,o=rx -d /opt/one-appliance/{,bin/}",
+    ]
+  }
+
+  provisioner "file" {
+    sources = [
+      "../one-apps/appliances/scripts/net-90-service-appliance",
+      "../one-apps/appliances/scripts/net-99-report-ready",
+    ]
+    destination = "/etc/one-appliance/"
+  }
+  provisioner "file" {
+    sources = [
+      "../one-apps/appliances/lib/common.sh",
+      "../one-apps/appliances/lib/functions.sh",
+    ]
+    destination = "/etc/one-appliance/lib/"
+  }
+  provisioner "file" {
+    source      = "../one-apps/appliances/service.sh"
+    destination = "/etc/one-appliance/service"
+  }
+  provisioner "file" {
+    sources     = ["appliances/Lithops/appliance.sh"]
+    destination = "/etc/one-appliance/service.d/"
+  }
+
+  provisioner "shell" {
+    scripts = ["${var.input_dir}/82-configure-context.sh"]
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -e"
+    inline         = ["/etc/one-appliance/service install && sync"]
+  }
+
+  post-processor "shell-local" {
+    execute_command = ["bash", "-c", "{{.Vars}} {{.Script}}"]
+    environment_vars = [
+      "OUTPUT_DIR=${var.output_dir}",
+      "APPLIANCE_NAME=${var.appliance_name}",
+    ]
+    scripts = ["../one-apps/packer/postprocess.sh"]
+  }
+}

--- a/apps-code/community-apps/packer/service_Lithops_Worker/common.pkr.hcl
+++ b/apps-code/community-apps/packer/service_Lithops_Worker/common.pkr.hcl
@@ -1,0 +1,1 @@
+../../../one-apps/packer/common.pkr.hcl

--- a/apps-code/community-apps/packer/service_Lithops_Worker/gen_context
+++ b/apps-code/community-apps/packer/service_Lithops_Worker/gen_context
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eux -o pipefail
+
+SCRIPT=$(cat <<'MAINEND'
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "PasswordAuthentication yes" }
+/^[#\s]*PasswordAuthentication\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+gawk -i inplace -f- /etc/ssh/sshd_config <<'EOF'
+BEGIN { update = "PermitRootLogin yes" }
+/^[#\s]*PermitRootLogin\s/ { $0 = update; found = 1 }
+{ print }
+ENDFILE { if (!found) print update }
+EOF
+
+systemctl reload sshd
+
+echo "nameserver 1.1.1.1" > /etc/resolv.conf
+MAINEND
+)
+
+cat<<EOF
+ETH0_METHOD='dhcp'
+NETWORK='YES'
+SET_HOSTNAME='Lithops'
+PASSWORD='opennebula'
+ETH0_MAC='00:11:22:33:44:55'
+NETCFG_TYPE='nm'
+START_SCRIPT_BASE64="$(echo "$SCRIPT" | base64 -w0)"
+EOF

--- a/apps-code/community-apps/packer/service_Lithops_Worker/variables.pkr.hcl
+++ b/apps-code/community-apps/packer/service_Lithops_Worker/variables.pkr.hcl
@@ -1,0 +1,22 @@
+variable "appliance_name" {
+  type    = string
+  default = "service_Lithops_Worker"
+}
+
+variable "input_dir" {
+  type = string
+}
+
+variable "output_dir" {
+  type = string
+}
+
+variable "headless" {
+  type    = bool
+  default = false
+}
+
+variable "version" {
+  type    = string
+  default = ""
+}


### PR DESCRIPTION
The old Lithops appliance consists of:

Lithops client VM
Lithops compute backend -> OneKE
Lithops storage backend -> MinIO appliance
The new Lithops appliance consists of:

Lithops client VM
Lithops compute backend -> KVM VMs
Lithops storage backend -> MinIO appliance
Lithops monitoring backend -> RabbitMQ appliance

Closes https://github.com/OpenNebula/engineering/issues/336