### PR TITLE
M #- : Workaround for UERANSIM version data

### DIFF
--- a/appliances/service/b37794e9-0264-403e-8184-27a7ee3d6b00.yaml
+++ b/appliances/service/b37794e9-0264-403e-8184-27a7ee3d6b00.yaml
@@ -17,7 +17,7 @@ os-id: Ubuntu
 os-release: 22.04 LTS
 os-arch: x86_64
 hypervisor: KVM
-opennebula_version: 6.4, 6.6, 6.8, 6.10
+opennebula_version: 6.4, 6.6, 6.8, 6.10, 7.0
 opennebula_template:
   context:
     network: 'YES'


### PR DESCRIPTION
A workaround to fix UERANSIM appliance appearance in the community marketplace (CMP) because without `7.0` it is not showing up in the CMP.