### PR TITLE
M #–: Make the Docker appliance generator work as documented

### DIFF
--- a/docs/AUTOMATIC_APPLIANCE_GUIDE.md
+++ b/docs/AUTOMATIC_APPLIANCE_GUIDE.md
@@ -1,35 +1,59 @@
 # Creating OpenNebula Appliances - Automatic Method
 
-**Quick appliance creation using the generator script (5 minutes)**
+**Quick appliance creation using the generator script**
 
 ---
 
 ## 📖 Introduction
 
-This guide shows you how to quickly create OpenNebula appliances from Docker containers using an automated generator script. The generator creates all necessary files following the proven Phoenix RTOS/Node-RED structure.
+This guide shows you how to quickly create OpenNebula appliances from Docker containers using an automated generator script. The generator creates all necessary files following the structure used by the appliances already in this repository.
 
 **What you'll create:**
-- A VM image (QCOW2 format) with Ubuntu 22.04 + Docker
+- A VM image (QCOW2 format) with Docker on the base OS you select (`BASE_OS`, default Ubuntu 22.04 minimal)
 - Automatic Docker container startup on VM boot
-- SSH access with password and key authentication
+- SSH access using the public key injected by OpenNebula context (`SSH_PUBLIC_KEY`) — password login is disabled and the root password is locked in the shipped image
 - Console and serial console auto-login
 - OpenNebula context integration for runtime configuration
 
-**Time required:** ~5 minutes for generation + 15-20 minutes for building
+**Time required:** ~1 minute for generation + ~2 minutes for building (plus a one-time ~2-3 minute base OS build)
 
 ---
 
 ## ✅ Prerequisites
 
-- Linux system (Ubuntu 22.04+ recommended)
-- Git
-- Packer (for building the image)
-- QEMU/KVM (for building the image)
+- **Linux host** (Ubuntu 22.04+ recommended). The generator uses GNU `sed -i`; it does **not** run on macOS/BSD.
+- **Root access** — the image build uses `chroot` and `/dev/kvm`, so `make` must be run as root (`sudo`).
+- **Hardware**: KVM enabled (`/dev/kvm` present), 8 GB+ RAM, 40 GB+ free disk.
+
+Install the build dependencies (official list:
+<https://github.com/OpenNebula/one-apps/wiki/tool_reqs>):
 
 ```bash
 sudo apt update
-sudo apt install -y git qemu-kvm qemu-utils
+sudo apt install -y \
+  bash cloud-utils cloud-image-utils genisoimage git gnupg lsb-release \
+  libguestfs0 libguestfs-tools make qemu-utils qemu-system-x86 \
+  rpm rsync ruby wget
+
+# Ruby gems required to build the one-context packages
+sudo gem install --no-document backports fpm
 ```
+
+Install Packer (>= 1.9.4) from HashiCorp — it is **not** in the Ubuntu archive:
+
+```bash
+wget -O- https://apt.releases.hashicorp.com/gpg \
+  | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+  | sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install -y packer
+packer version
+```
+
+> `fpm`, `rpm` and `cloud-image-utils` (which provides `cloud-localds`) are the
+> three that are almost never already installed and whose absence fails the
+> build with a confusing error.
 
 ---
 
@@ -40,10 +64,32 @@ sudo apt install -y git qemu-kvm qemu-utils
 ```bash
 git clone https://github.com/OpenNebula/marketplace-community.git
 cd marketplace-community
-git checkout dcos/add-appliance-automation-script
+
+# REQUIRED: everything the build needs lives behind the one-apps submodule.
+# Without this, apps-code/one-apps is empty and
+# apps-code/community-apps/packer/build.sh is a dangling symlink, so
+# `make <name>` fails immediately.
+git submodule update --init --recursive
 ```
 
-### Step 2: Create Configuration File
+### Step 2: Build the Base OS Image (once per host)
+
+`make <name>` in `community-apps` **never** builds the base image for you: the
+generated Packer template consumes `apps-code/one-apps/export/<BASE_OS>.qcow2`
+and fails if it is missing. Build it once (the default `BASE_OS` is
+`ubuntu2204min`):
+
+```bash
+cd apps-code/one-apps
+sudo make ubuntu2204min      # ~2-3 min -> export/ubuntu2204min.qcow2
+cd ../..
+```
+
+This also builds the one-context packages, which is why `fpm` and `rpm` are
+required. Docker is **not** needed on the build host. The base image is reused
+by every appliance you generate afterwards.
+
+### Step 3: Create Configuration File
 
 Create a `.env` file with your Docker container details:
 
@@ -52,7 +98,7 @@ cd docs/automatic-appliance-tutorial
 
 cat > myapp.env << 'ENVEOF'
 # Required variables
-DOCKER_IMAGE="your-docker-image:tag"
+DOCKER_IMAGE="your-docker-image:1.2.3"   # must be a pinned tag, not :latest
 APPLIANCE_NAME="myapp"
 APP_NAME="MyApp"
 PUBLISHER_NAME="Your Name"
@@ -67,51 +113,80 @@ DEFAULT_ENV_VARS=""
 DEFAULT_VOLUMES="/data:/data"
 APP_PORT="8080"
 WEB_INTERFACE="true"
+BASE_OS="ubuntu2204min"
 ENVEOF
 ```
 
-### Step 3: Run Generator
+### Step 4: Run Generator
 
 ```bash
-./generate-docker-appliance.sh myapp.env
+./generate-docker-appliance.sh myapp.env --no-build
 ```
 
 The generator will:
 1. Create all appliance files
-2. Generate Packer configuration
-3. Prompt you to build the image immediately
+2. Generate the Packer build definition
+3. Register the appliance in `apps-code/community-apps/Makefile.config`
+   (`SERVICES` list) so that `make <name>` works
+4. Prompt you to build the image immediately — **only when stdin is a TTY**, and
+   only if you did not pass `--no-build`. Piped / CI / `ssh host bash -s` runs
+   skip the prompt and exit 0.
+
+**Flags:**
+
+| Flag | Effect |
+|------|--------|
+| `--no-build` | Generate only; never prompt, never build. Use this for CI and non-interactive runs. |
+| `--force` | Regenerate over an existing appliance. Without it the generator refuses to overwrite `appliances/<name>/` or `packer/<name>/` and exits 1. `--force` wipes both directories first (a new appliance UUID is generated). |
+| `-h`, `--help` | Show usage and exit. |
+
+```bash
+# non-interactive / CI
+./generate-docker-appliance.sh myapp.env --no-build
+
+# regenerate an appliance you already created
+./generate-docker-appliance.sh myapp.env --force
+```
 
 **Output:**
 ```
-🚀 Loading configuration from myapp.env
-🎯 Generating complete appliance: myapp (MyApp)
-📁 Creating directory structure...
-✅ Directory structure created
-📝 Generating metadata.yaml...
-✅ Metadata files generated
-📝 Generating README.md...
-✅ README.md generated
-📝 Generating appliance.sh installation script...
-✅ appliance.sh generated
-📝 Generating Packer configuration files...
-✅ Packer configuration files generated
-🎉 Appliance 'myapp' generated successfully!
-
-Do you want to build the image now? (y/n):
+[INFO] 🚀 Loading configuration from myapp.env
+[INFO] 🎯 Generating complete appliance: myapp (MyApp)
+[INFO] 📁 Creating directory structure...
+[SUCCESS] Directory structure created
+[INFO] 📝 Generating metadata.yaml...
+[INFO] 📝 Generating <uuid>.yaml...
+[SUCCESS] Metadata files generated
+[INFO] 📝 Generating README.md...
+[SUCCESS] README.md generated
+[INFO] 📝 Generating appliance.sh installation script...
+[SUCCESS] appliance.sh generated
+[INFO] 📝 Generating Packer configuration files...
+[INFO] 📝 Generating additional required files...
+[SUCCESS] Additional files generated
+[SUCCESS] Packer configuration files generated
+[INFO] 📝 Adding 'myapp' to Makefile.config SERVICES list...
+[SUCCESS]   ✅ Added 'myapp' to SERVICES list
+[INFO] 🎉 Appliance 'myapp' generated successfully!
 ```
 
-### Step 4: Build the Image
+### Step 5: Build the Appliance Image
 
-If you answered 'y' to the prompt, the build starts automatically. Otherwise:
+Step 4 above passes `--no-build`, so the image has not been built yet. (If you
+run the generator *without* `--no-build` on a TTY and answer 'y' to its build
+prompt, it does this for you — that path initialises the submodule and builds
+the base image first.) To build it yourself:
 
 ```bash
 cd ../../apps-code/community-apps
-make myapp
+sudo make myapp
 ```
 
-**Build time:** 15-20 minutes (downloads Ubuntu, installs Docker, pulls your container image)
+**Build time:** ~2 minutes. The build boots the base qcow2, installs Docker CE,
+and **pulls your Docker image into the qcow2 at build time**. No Ubuntu ISO is
+downloaded.
 
-**Output file:** `export/myapp.qcow2`
+**Output file:** `apps-code/community-apps/export/myapp.qcow2`
 
 ---
 
@@ -119,7 +194,7 @@ make myapp
 
 | Variable | Required | Description | Example |
 |----------|----------|-------------|---------|
-| `DOCKER_IMAGE` | Yes | Docker image name | `nginx:alpine` |
+| `DOCKER_IMAGE` | Yes | Docker image name, pinned tag or digest | `nginx:alpine` |
 | `APPLIANCE_NAME` | Yes | Lowercase name (no spaces) | `nginx` |
 | `APP_NAME` | Yes | Display name | `NGINX Web Server` |
 | `PUBLISHER_NAME` | Yes | Your name | `John Doe` |
@@ -132,6 +207,24 @@ make myapp
 | `DEFAULT_VOLUMES` | No | Volume mappings | `/data:/data,/config:/config` |
 | `APP_PORT` | No | Main application port | `80` |
 | `WEB_INTERFACE` | No | Has web UI? | `true` or `false` |
+| `BASE_OS` | No | Base OS image to build on (default `ubuntu2204min`) | `ubuntu2404min` |
+
+**`BASE_OS`** is set inside the `.env` file, not on the command line. Supported
+values (anything else is rejected with exit 1):
+
+`ubuntu2204min` `ubuntu2204` `ubuntu2404min` `ubuntu2404` `debian12` `debian11`
+`alma8` `alma9` `rocky8` `rocky9` `opensuse15`
+
+Whichever value you pick, `apps-code/one-apps/export/<BASE_OS>.qcow2` must be
+built before `make <name>` (see Step 2).
+
+**`DOCKER_IMAGE` must be pinned.** An untagged image or an explicit `:latest`
+tag is rejected — use a released tag (`nginx:1.27-alpine`) or a digest
+(`nginx@sha256:...`).
+
+**`DEFAULT_ENV_VARS` is baked into the image.** Never put a real secret there.
+Secrets (database passwords, API keys) belong in the `ONEAPP_CONTAINER_ENV`
+context variable, supplied at instantiation time.
 
 ---
 
@@ -142,16 +235,25 @@ The generator creates:
 ```
 marketplace-community/
 ├── appliances/myapp/
-│   ├── appliance.sh          # Installation script
-│   ├── metadata.yaml         # Build configuration
-│   ├── <uuid>.yaml          # Marketplace metadata
-│   ├── README.md            # Documentation
-│   ├── CHANGELOG.md         # Version history
+│   ├── appliance.sh              # install / configure / bootstrap logic
+│   ├── metadata.yaml             # appliance descriptor (:app: / :one: / :infra:)
+│   ├── <uuid>.yaml               # marketplace appliance definition
+│   ├── context.yaml              # default context values used by the tests
+│   ├── README.md                 # documentation
+│   ├── CHANGELOG.md              # version history
+│   ├── tests.yaml                # list of test files
 │   └── tests/
-│       └── tests.yaml       # Test configuration
-└── apps-code/community-apps/packer/myapp/
-    ├── myapp.pkr.hcl        # Packer build file
-    └── myapp.auto.pkrvars.hcl  # Packer variables
+│       └── 00-myapp_basic.rb     # RSpec certification test
+├── apps-code/community-apps/packer/myapp/
+│   ├── myapp.pkr.hcl             # Packer build definition
+│   ├── variables.pkr.hcl         # Packer variables
+│   ├── common.pkr.hcl            # symlink to one-apps/packer/common.pkr.hcl
+│   ├── 81-configure-ssh.sh       # re-hardens sshd (key-only) during the build
+│   ├── 82-configure-context.sh   # installs the one-context hooks
+│   ├── gen_context               # build-time context ISO generator
+│   ├── postprocess.sh            # post-build hook
+│   └── .gitignore                # ignores transient build artifacts only
+└── apps-code/community-apps/Makefile.config   # MODIFIED: myapp appended to SERVICES
 ```
 
 ---
@@ -192,17 +294,27 @@ service_install()
 
 ### Rebuild After Changes
 
+`make` treats `export/myapp.qcow2` as an up-to-date target, so a plain
+`make myapp` is a no-op once the image exists. Delete just your own image and
+rebuild:
+
 ```bash
 cd apps-code/community-apps
-make clean
-make myapp
+sudo rm -f export/myapp.qcow2
+sudo make myapp
 ```
+
+Do not use `make clean` for this: it is `rm -rf export/*` and wipes every
+appliance image you have built, not only `myapp`.
 
 ---
 
 ## 📦 Examples
 
-See `docs/automatic-appliance-tutorial/examples/` for complete working examples:
+The four `.env` files in `docs/automatic-appliance-tutorial/examples/` have each
+been generated, built and booted. The blocks below are trimmed versions of them
+(`APP_DESCRIPTION` and `APP_FEATURES` are optional and get sensible defaults);
+use the shipped files verbatim if you want the exact tested configuration.
 
 ### NGINX Web Server
 
@@ -210,24 +322,28 @@ See `docs/automatic-appliance-tutorial/examples/` for complete working examples:
 cat > nginx.env << 'EOF'
 DOCKER_IMAGE="nginx:alpine"
 APPLIANCE_NAME="nginx"
-APP_NAME="NGINX"
+APP_NAME="NGINX Web Server"
 PUBLISHER_NAME="Your Name"
 PUBLISHER_EMAIL="your@email.com"
 DEFAULT_PORTS="80:80,443:443"
+# No default volumes: mounting empty host directories over the image's own
+# /etc/nginx/conf.d (default.conf) or /usr/share/nginx/html hides the image's
+# built-in config and default page, leaving nginx with nothing to serve.
+DEFAULT_VOLUMES=""
 APP_PORT="80"
 WEB_INTERFACE="true"
 EOF
 
-./generate-docker-appliance.sh nginx.env
+./generate-docker-appliance.sh nginx.env --no-build
 ```
 
 ### Node-RED
 
 ```bash
 cat > nodered.env << 'EOF'
-DOCKER_IMAGE="nodered/node-red:latest"
+DOCKER_IMAGE="nodered/node-red:5.0.1"
 APPLIANCE_NAME="nodered"
-APP_NAME="Node-RED"
+APP_NAME="Node-Red"
 PUBLISHER_NAME="Your Name"
 PUBLISHER_EMAIL="your@email.com"
 DEFAULT_PORTS="1880:1880"
@@ -236,47 +352,68 @@ APP_PORT="1880"
 WEB_INTERFACE="true"
 EOF
 
-./generate-docker-appliance.sh nodered.env
+./generate-docker-appliance.sh nodered.env --no-build
 ```
+
+The tag is pinned to match `docs/automatic-appliance-tutorial/examples/nodered.env`:
+`nodered/node-red:latest` is rejected by the generator.
 
 ### PostgreSQL Database
 
 ```bash
 cat > postgres.env << 'EOF'
-DOCKER_IMAGE="postgres:16-alpine"
+DOCKER_IMAGE="postgres:15"
 APPLIANCE_NAME="postgres"
-APP_NAME="PostgreSQL"
+APP_NAME="PostgreSQL Database"
 PUBLISHER_NAME="Your Name"
 PUBLISHER_EMAIL="your@email.com"
 DEFAULT_PORTS="5432:5432"
-DEFAULT_ENV_VARS="POSTGRES_PASSWORD=changeme"
+DEFAULT_ENV_VARS="POSTGRES_DB=appdb,POSTGRES_USER=postgres"
 DEFAULT_VOLUMES="/var/lib/postgresql/data:/var/lib/postgresql/data"
 APP_PORT="5432"
 WEB_INTERFACE="false"
 EOF
 
-./generate-docker-appliance.sh postgres.env
+./generate-docker-appliance.sh postgres.env --no-build
 ```
 
-### Nextcloud All-in-One
+**Note:** `POSTGRES_PASSWORD` is deliberately absent from `DEFAULT_ENV_VARS` —
+anything you put there is baked into the published image. PostgreSQL refuses to
+initialise without it, so it **must** be supplied at instantiation through the
+context variable, e.g.
+`ONEAPP_CONTAINER_ENV = "POSTGRES_PASSWORD=<your-password>"` in the VM
+template's `CONTEXT` section.
+
+### Redis Cache
 
 ```bash
-cat > nextcloud.env << 'EOF'
-DOCKER_IMAGE="nextcloud/all-in-one:latest"
-APPLIANCE_NAME="nextcloud"
-APP_NAME="Nextcloud"
+cat > redis.env << 'EOF'
+DOCKER_IMAGE="redis:alpine"
+APPLIANCE_NAME="redis"
+APP_NAME="Redis Cache"
 PUBLISHER_NAME="Your Name"
 PUBLISHER_EMAIL="your@email.com"
-DEFAULT_PORTS="80:80,8080:8080,8443:8443"
-DEFAULT_VOLUMES="/var/run/docker.sock:/var/run/docker.sock:ro,nextcloud_aio_mastercontainer:/mnt/docker-aio-config"
-APP_PORT="8080"
-WEB_INTERFACE="true"
+DEFAULT_PORTS="6379:6379"
+DEFAULT_VOLUMES="/data:/data"
+APP_PORT="6379"
+WEB_INTERFACE="false"
 EOF
 
-./generate-docker-appliance.sh nextcloud.env
+./generate-docker-appliance.sh redis.env --no-build
 ```
 
-**Note**: Nextcloud All-in-One requires access to the Docker socket for managing additional containers. Access the web interface at `http://VM_IP:8080` to complete the setup.
+**Note:** the generator refuses two classes of configuration outright, so they
+can never appear in a working example:
+
+- `DOCKER_IMAGE` with an explicit `:latest` tag, or with no tag at all (both
+  resolve to a mutable tag). Pin a released tag (`nginx:1.27-alpine`) or a
+  digest (`nginx@sha256:...`).
+- `DEFAULT_VOLUMES` mapping a sensitive host path — `/var/run/docker.sock`,
+  `/run/docker.sock`, `/`, `/root`, `/proc`, `/sys`, `/dev`, `/boot`,
+  `/var/run`, `/run`, `/usr`, `/bin`, `/sbin`, `/lib`, `/lib64`,
+  `/var/lib/docker`. These are container-escape vectors. Docker-in-Docker
+  style appliances (e.g. Nextcloud All-in-One, which needs the Docker socket)
+  cannot be produced by this generator.
 
 ---
 
@@ -340,7 +477,11 @@ NIC = [
 CONTEXT = [
   NETWORK = "YES",
   SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]",
-  SET_HOSTNAME = "$NAME"
+  SET_HOSTNAME = "$NAME",
+  ONEAPP_CONTAINER_NAME = "myapp-container",
+  ONEAPP_CONTAINER_PORTS = "8080:8080",
+  ONEAPP_CONTAINER_ENV = "",
+  ONEAPP_CONTAINER_VOLUMES = ""
 ]
 GRAPHICS = [
   TYPE = "VNC",
@@ -351,6 +492,12 @@ EOF
 # Create the template
 onetemplate create myapp-template.txt
 ```
+
+**Note:** the `ONEAPP_CONTAINER_*` variables are how the appliance is configured
+at instantiation; omit them and the container falls back to the defaults baked
+in at generation time. Container environment variables may carry secrets (DB
+passwords, API keys), so always supply them here via `ONEAPP_CONTAINER_ENV`
+rather than committing them into the appliance files.
 
 **Note:** The command will output a TEMPLATE_ID (e.g., `ID: 5`). Save this ID for the next step.
 
@@ -380,6 +527,11 @@ Once the VM is running, you can access it via SSH and the web interface (if appl
 
 **SSH Access:**
 
+The deployed appliance accepts **only** the public key delivered through the
+`SSH_PUBLIC_KEY` context variable. Password authentication is disabled and the
+root password is locked, so make sure your key is in the template's CONTEXT
+before instantiating.
+
 ```bash
 # If OpenNebula is on a remote host, use SSH port forwarding
 # Replace:
@@ -401,7 +553,7 @@ http://localhost:8080
 **Direct SSH to VM:**
 
 ```bash
-# From the OpenNebula host
+# From the OpenNebula host, using the private key matching SSH_PUBLIC_KEY
 ssh root@172.16.100.X
 
 # Verify the container is running
@@ -418,7 +570,7 @@ docker logs <container-name>
 - ✅ Docker service is running (`systemctl status docker`)
 - ✅ Container is running (`docker ps`)
 - ✅ Application is accessible via web interface (if applicable)
-- ✅ SSH access works with password and key authentication
+- ✅ SSH access works with the context-injected key (`ssh root@<VM_IP>`); password login is correctly refused
 - ✅ Console auto-login works (check via VNC)
 
 ---
@@ -431,10 +583,10 @@ Create a 256x256 PNG logo for your appliance to display in the OpenNebula Sunsto
 
 #### Step 1: Create or Download the Logo
 
-**Option A: Download from official source**
+**Option A: Download from the project's official source**
 ```bash
-# Example: Download Nextcloud logo
-wget -O /tmp/app-logo.png "https://raw.githubusercontent.com/nextcloud/promo/master/nextcloud-logo-inverted.png"
+# Replace the URL with the official logo of the application you are packaging
+wget -O /tmp/app-logo.png "https://example.com/path/to/official-logo.png"
 ```
 
 **Option B: Create your own logo**
@@ -504,24 +656,6 @@ onetemplate show TEMPLATE_ID | grep LOGO
 3. You should see your logo displayed next to the appliance
 4. If not visible, do a hard refresh (Ctrl+Shift+R or Cmd+Shift+R)
 
-**Example for Nextcloud:**
-```bash
-# Download and prepare logo
-wget -O /tmp/nextcloud-logo.png "https://raw.githubusercontent.com/nextcloud/promo/master/nextcloud-logo-inverted.png"
-convert /tmp/nextcloud-logo.png -resize 256x256 -background none -gravity center -extent 256x256 logos/nextcloud.png
-
-# Deploy to OpenNebula
-sudo cp logos/nextcloud.png /usr/lib/one/fireedge/dist/client/assets/images/logos/
-sudo systemctl restart opennebula-fireedge
-
-# Update image and template
-cat > /tmp/logo-update.txt << 'EOF'
-LOGO = "images/logos/nextcloud.png"
-EOF
-oneimage update 4 /tmp/logo-update.txt
-onetemplate update 3 /tmp/logo-update.txt
-```
-
 ### 2. Submit to Marketplace
 
 Once your appliance is tested and working, submit it to the OpenNebula Marketplace:
@@ -533,6 +667,7 @@ Once your appliance is tested and working, submit it to the OpenNebula Marketpla
 # Then clone your fork
 git clone https://github.com/YOUR_USERNAME/marketplace-community.git
 cd marketplace-community
+git submodule update --init --recursive
 
 # Create feature branch
 git checkout -b feature/add-myapp-appliance
@@ -543,13 +678,17 @@ git checkout -b feature/add-myapp-appliance
 ```bash
 git add appliances/myapp/
 git add apps-code/community-apps/packer/myapp/
+# REQUIRED: the generator appended your appliance to the SERVICES list.
+# Without this file `make myapp` fails with "No rule to make target",
+# and the PR cannot be built.
+git add apps-code/community-apps/Makefile.config
 git add logos/myapp.png
 
 git commit -m "Add MyApp appliance
 
 - Docker container with automatic startup
 - OpenNebula context integration
-- SSH and console access
+- SSH (key-only) and console access
 - Web interface on port 8080"
 ```
 
@@ -574,17 +713,17 @@ This PR adds a new appliance for MyApp, a [brief description].
 - Docker container with automatic startup
 - OpenNebula context integration
 - Configurable via context variables:
-  - Container name
-  - Port mappings
-  - Environment variables
-  - Volume mappings
+  - ONEAPP_CONTAINER_NAME
+  - ONEAPP_CONTAINER_PORTS
+  - ONEAPP_CONTAINER_ENV
+  - ONEAPP_CONTAINER_VOLUMES
 
 ## Testing
 
 - ✅ Built successfully with Packer
 - ✅ Deployed to OpenNebula
 - ✅ Container starts automatically
-- ✅ SSH access works (password + keys)
+- ✅ SSH access works with the OpenNebula context-injected key (password login disabled)
 - ✅ Console auto-login works
 - ✅ Application accessible on configured ports
 
@@ -592,6 +731,7 @@ This PR adds a new appliance for MyApp, a [brief description].
 
 - `appliances/myapp/` - Appliance definition files
 - `apps-code/community-apps/packer/myapp/` - Packer build configuration
+- `apps-code/community-apps/Makefile.config` - appliance added to SERVICES
 - `logos/myapp.png` - Appliance logo
 
 ## Checklist
@@ -601,6 +741,7 @@ This PR adds a new appliance for MyApp, a [brief description].
 - [x] Documentation included (README.md)
 - [x] Logo added (256x256 PNG)
 - [x] Follows community appliance structure
+- [x] Docker image pinned to an immutable tag or digest
 - [x] No sensitive information in files
 ```
 
@@ -618,6 +759,14 @@ This PR adds a new appliance for MyApp, a [brief description].
 grep -E "DOCKER_IMAGE|APPLIANCE_NAME|APP_NAME|PUBLISHER" myapp.env
 ```
 
+**Problem:** `Refusing to overwrite. Re-run with --force to replace it.`  
+**Solution:** The appliance already exists. Re-run with `--force` (it wipes
+`appliances/<name>/` and `packer/<name>/` first and assigns a new UUID).
+
+**Problem:** The generator aborts with a `sed` error  
+**Solution:** You are not on Linux. The generator requires GNU `sed -i`; run it
+on a Linux host.
+
 ### Build Fails
 
 **Problem:** Packer build fails  
@@ -625,13 +774,16 @@ grep -E "DOCKER_IMAGE|APPLIANCE_NAME|APP_NAME|PUBLISHER" myapp.env
 
 ```bash
 cd apps-code/community-apps
-make myapp 2>&1 | tee build.log
+sudo make myapp 2>&1 | tee build.log
 ```
 
 Common issues:
-- Network connectivity (can't download Ubuntu ISO)
-- Insufficient disk space
-- Docker image doesn't exist or is private
+- Base image missing — build it first: `cd apps-code/one-apps && sudo make ubuntu2204min`
+- Not running as root, or `/dev/kvm` is unavailable
+- Missing build dependencies: `fpm` (ruby gem), `rpm`, `cloud-image-utils` (provides `cloud-localds`)
+- Submodule not initialised — `apps-code/community-apps/packer/build.sh` is a dangling symlink until you run `git submodule update --init --recursive`
+- Insufficient disk space (40 GB+ free needed)
+- Docker image doesn't exist, is private, or was rejected for using a mutable `:latest` tag
 
 ### Container Doesn't Start
 
@@ -646,13 +798,25 @@ grep "DOCKER_IMAGE=" appliances/myapp/appliance.sh
 ### Permission Issues
 
 **Problem:** Container can't write to volumes  
-**Solution:** The generator automatically sets ownership to `1000:1000`. If your container uses a different UID, edit `appliance.sh`:
+**Solution:** When the appliance has to **create** a host directory for a volume
+mount, it chowns that newly created directory to the UID/GID the container image
+runs as (resolved from the image itself), which is what makes volumes work for
+images that run unprivileged. It deliberately never touches a **pre-existing**
+host directory — no recursive chown of an existing tree.
+
+So if the mount point already exists on the host with the wrong ownership, fix
+it yourself in the `service_install()` function of
+`appliances/myapp/appliance.sh`:
 
 ```bash
 # In service_install() function
 mkdir -p /data
-chown 1001:1001 /data  # Change to your container's UID:GID
+chown 1000:1000 /data  # use your container's UID:GID
 ```
+
+Then rebuild the image for the change to take effect (see
+"Rebuild After Changes" — deleting `export/myapp.qcow2` first is required,
+otherwise `make` considers the target up to date and does nothing).
 
 ---
 
@@ -660,10 +824,12 @@ chown 1001:1001 /data  # Change to your container's UID:GID
 
 - **Start simple** - Begin with minimal configuration, add features incrementally
 - **Use official images** - Prefer official Docker images from Docker Hub
+- **Pin the tag** - `:latest` and untagged images are rejected; a pinned tag or digest keeps rebuilds reproducible
 - **Test the Docker image first** - Run `docker run` locally before generating appliance
 - **Check examples** - Study the example .env files for reference
-- **Volume permissions** - If container runs as non-root, ensure volume directories have correct ownership
-- **Environment variables** - Use DEFAULT_ENV_VARS for container configuration
+- **Volume permissions** - A host directory that already exists is never re-owned by the appliance; make sure its ownership matches the container's UID
+- **Don't shadow image content** - Mounting an empty host directory over a path the image populates (e.g. nginx's `/etc/nginx/conf.d`) hides the image's own files
+- **Secrets** - Pass them at instantiation via `ONEAPP_CONTAINER_ENV`, never in `DEFAULT_ENV_VARS`
 - **Port conflicts** - Ensure ports don't conflict with system services
 
 ---
@@ -671,8 +837,8 @@ chown 1001:1001 /data  # Change to your container's UID:GID
 ## 📖 Additional Resources
 
 - [Manual Appliance Guide](MANUAL_APPLIANCE_GUIDE.md) - For advanced customization
+- [one-apps build requirements](https://github.com/OpenNebula/one-apps/wiki/tool_reqs)
 - [OpenNebula Documentation](https://docs.opennebula.io/)
 - [Docker Hub](https://hub.docker.com/)
 - [Packer Documentation](https://www.packer.io/docs)
 - [OpenNebula Marketplace](https://marketplace.opennebula.io/)
-

--- a/docs/AUTOMATIC_APPLIANCE_GUIDE.md
+++ b/docs/AUTOMATIC_APPLIANCE_GUIDE.md
@@ -170,6 +170,20 @@ The generator will:
 [INFO] 🎉 Appliance 'myapp' generated successfully!
 ```
 
+### About the image size
+
+The generated `service_install()` installs `linux-image-generic` plus the
+matching `linux-modules-extra` and makes it the default GRUB entry. The minimal
+base images ship a `-kvm` kernel with no Virtual Terminal support, which makes
+the Sunstone VNC console come up as a black screen; the generic kernel fixes
+that. It also costs roughly a gigabyte in the exported qcow2 (a generated NGINX
+appliance measures ~1.4 GB, versus ~240 MB for the same appliance built without
+the kernel swap).
+
+If your appliance is headless and you do not care about the VNC console, delete
+that block from `appliances/<name>/appliance.sh` before building and the image
+shrinks accordingly.
+
 ### Step 5: Build the Appliance Image
 
 Step 4 above passes `--no-build`, so the image has not been built yet. (If you

--- a/docs/AUTOMATIC_APPLIANCE_GUIDE.md
+++ b/docs/AUTOMATIC_APPLIANCE_GUIDE.md
@@ -499,6 +499,25 @@ in at generation time. Container environment variables may carry secrets (DB
 passwords, API keys), so always supply them here via `ONEAPP_CONTAINER_ENV`
 rather than committing them into the appliance files.
 
+**List separators.** `ONEAPP_CONTAINER_PORTS`, `ONEAPP_CONTAINER_ENV` and
+`ONEAPP_CONTAINER_VOLUMES` hold lists. The appliance accepts **either `,` or `;`**
+between items, so all of these are equivalent:
+
+```
+ONEAPP_CONTAINER_PORTS = "80:80,443:443"
+ONEAPP_CONTAINER_PORTS = "80:80;443:443"
+```
+
+Use whichever reads better in Sunstone. One place where it matters: the
+certification harness (`lib/community/app_handler.rb`) joins the
+`metadata.yaml` `:params:` entries with commas and hands the result to
+`onetemplate instantiate --context`, and the CLI splits that string on commas
+regardless of quoting. A comma *inside* a value is therefore truncated there
+(`"80:80,443:443"` arrives as `"80:80,"`). For that reason the generator writes
+the `:params:` defaults in `metadata.yaml` with `;`, and you should keep it that
+way. The same caution applies whenever you pass a list through
+`--context` on the command line — prefer `;` there.
+
 **Note:** The command will output a TEMPLATE_ID (e.g., `ID: 5`). Save this ID for the next step.
 
 #### Step 2.3: Instantiate the VM

--- a/docs/AUTOMATIC_APPLIANCE_GUIDE.md
+++ b/docs/AUTOMATIC_APPLIANCE_GUIDE.md
@@ -592,6 +592,52 @@ docker logs <container-name>
 - ✅ SSH access works with the context-injected key (`ssh root@<VM_IP>`); password login is correctly refused
 - ✅ Console auto-login works (check via VNC)
 
+### 3. Run the Certification Tests
+
+The generator writes an rspec test at
+`appliances/myapp/tests/00-myapp_basic.rb` and lists it in
+`appliances/myapp/tests.yaml`. The community harness
+(`lib/community/app_readiness.rb`) creates the image, instantiates a VM from
+your `metadata.yaml` `:params:` and runs the test against it. On the frontend:
+
+```bash
+# rspec is not part of the OpenNebula gem set; install it once
+sudo gem install --no-document rspec
+
+# the image must be readable by oneadmin (oned runs as oneadmin)
+sudo cp apps-code/community-apps/export/myapp.qcow2 /var/tmp/
+sudo chmod 644 /var/tmp/myapp.qcow2
+
+sudo -u oneadmin env IMAGES_URL=/var/tmp/ \
+  bash -c 'cd lib/community && mkdir -p results && ./app_readiness.rb myapp'
+```
+
+Expected output:
+
+```
+Appliance Certification
+  docker engine is active
+  MyApp image (myimage:1.2.3) is present
+  MyApp container (myapp-container) is running
+
+3 examples, 0 failures
+```
+
+Requirements that are easy to miss:
+
+- **Run as `oneadmin`.** The harness reaches the VM with `ssh root@<vm-ip>` and
+  the VM only trusts the key contextualization injected from
+  `$USER[SSH_PUBLIC_KEY]`, which is oneadmin's. Running as root gives
+  `Permission denied (publickey)` and every example fails with
+  `reached timeout ... reachable?`.
+- **`IMAGES_URL` must be readable by oneadmin.** A path under `/root` fails with
+  `Cannot parse image SIZE: ... (Permission denied)`.
+- **A VM template named `base` must exist** (`defaults.yaml` sets
+  `:template: base`); the harness instantiates it with `--disk <image>` plus the
+  context built from `metadata.yaml`.
+
+Results are written to `lib/community/results/myapp/`.
+
 ---
 
 ## 📤 Next Steps

--- a/docs/AUTOMATIC_APPLIANCE_GUIDE.md
+++ b/docs/AUTOMATIC_APPLIANCE_GUIDE.md
@@ -176,9 +176,9 @@ The generated `service_install()` installs `linux-image-generic` plus the
 matching `linux-modules-extra` and makes it the default GRUB entry. The minimal
 base images ship a `-kvm` kernel with no Virtual Terminal support, which makes
 the Sunstone VNC console come up as a black screen; the generic kernel fixes
-that. It also costs roughly a gigabyte in the exported qcow2 (a generated NGINX
-appliance measures ~1.4 GB, versus ~240 MB for the same appliance built without
-the kernel swap).
+that. It also roughly doubles the exported qcow2: a generated NGINX appliance
+measures ~1.4 GB, against ~0.6 GB for an equivalent appliance built without the
+kernel swap.
 
 If your appliance is headless and you do not care about the VNC console, delete
 that block from `appliances/<name>/appliance.sh` before building and the image

--- a/docs/AUTOMATIC_APPLIANCE_GUIDE.md
+++ b/docs/AUTOMATIC_APPLIANCE_GUIDE.md
@@ -222,6 +222,7 @@ downloaded.
 | `APP_PORT` | No | Main application port | `80` |
 | `WEB_INTERFACE` | No | Has web UI? | `true` or `false` |
 | `BASE_OS` | No | Base OS image to build on (default `ubuntu2204min`) | `ubuntu2404min` |
+| `DISK_SIZE` | No | Appliance virtual disk size in MiB (default `20480`) | `20480` |
 
 **`BASE_OS`** is set inside the `.env` file, not on the command line. Supported
 values (anything else is rejected with exit 1):
@@ -231,6 +232,19 @@ values (anything else is rejected with exit 1):
 
 Whichever value you pick, `apps-code/one-apps/export/<BASE_OS>.qcow2` must be
 built before `make <name>` (see Step 2).
+
+**`DISK_SIZE`** is the appliance's virtual disk in MiB. Packer can only *grow*
+the base image, so it must be at least as large as the base you selected — the
+bases differ widely (`ubuntu2204min` is 2.2 GiB, `alma9` is 10 GiB). Asking for
+less aborts the build with:
+
+```
+Error creating hard drive: QemuImg error: qemu-img:
+Use the --shrink option to perform a shrink operation.
+```
+
+The default of `20480` clears every supported base. qcow2 is sparse, so a
+generous virtual size does not make the exported file bigger.
 
 **`DOCKER_IMAGE` must be pinned.** An untagged image or an explicit `:latest`
 tag is rejected — use a released tag (`nginx:1.27-alpine`) or a digest

--- a/docs/MANUAL_APPLIANCE_GUIDE.md
+++ b/docs/MANUAL_APPLIANCE_GUIDE.md
@@ -1,133 +1,291 @@
 # Creating OpenNebula Appliances - Manual Method
 
-**Complete control over appliance creation (30-45 minutes)**
+**Complete control over appliance creation**
 
 ---
 
 ## 📖 Introduction
 
-This guide shows you how to manually create OpenNebula appliances from Docker containers. This approach gives you full control over every aspect of the appliance and is recommended for advanced users or custom requirements.
+This guide shows you how to manually create OpenNebula appliances from Docker
+containers. This approach gives you full control over every aspect of the
+appliance and is recommended for advanced users or custom requirements.
+
+If you just want a working appliance quickly, use the generator instead:
+[Automatic Appliance Guide](AUTOMATIC_APPLIANCE_GUIDE.md).
 
 **What you'll create:**
-- A VM image (QCOW2 format) with Ubuntu 22.04 + Docker
-- Automatic Docker container startup on VM boot
-- SSH access with password and key authentication
-- Console and serial console auto-login
+- A VM image (QCOW2 format) built on the one-apps Ubuntu 22.04 minimal base
+- Docker installed at build time and your container started on first boot
+- SSH key-only access (the public key is injected from OpenNebula context,
+  `$USER[SSH_PUBLIC_KEY]`; there is no password login on the deployed VM)
 - OpenNebula context integration for runtime configuration
+  (`ONEAPP_CONTAINER_NAME`, `ONEAPP_CONTAINER_PORTS`, `ONEAPP_CONTAINER_ENV`,
+  `ONEAPP_CONTAINER_VOLUMES`)
 
-**Time required:** ~30-45 minutes for creation + 15-20 minutes for building
+**Time required:** ~30-45 minutes to write the files, plus roughly 5 minutes of
+build time (base OS image ~2.5 min, appliance image ~2 min).
+
+Throughout this guide the example appliance is called `myapp`. Replace it with
+your own lowercase name (letters, digits and hyphens only).
 
 ---
 
 ## ✅ Prerequisites
 
-- Linux system (Ubuntu 22.04+ recommended)
-- Git
-- Text editor (nano, vim, or VS Code)
-- Basic knowledge of bash scripting and YAML
-- Packer (for building the image)
-- QEMU/KVM (for building the image)
+The build **must run on Linux, as root** (it uses `chroot`), on a host with KVM
+(`/dev/kvm` present), at least 8 GB RAM and 40 GB free disk. macOS/BSD will not
+work.
+
+Full authoritative list: <https://github.com/OpenNebula/one-apps/wiki/tool_reqs>
 
 ```bash
 sudo apt update
-sudo apt install -y git qemu-kvm qemu-utils nano
+sudo apt install -y make ruby rpm rsync genisoimage cloud-utils cloud-image-utils \
+                    qemu-utils qemu-system-x86 libguestfs-tools
+sudo gem install --no-document backports fpm
+
+#    Packer >= 1.9.4 is NOT in the Ubuntu archive - install HashiCorp's package:
+wget -O- https://apt.releases.hashicorp.com/gpg | \
+  sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+  sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install -y packer
 ```
+
+Verify the host is ready:
+
+```bash
+packer --version        # must be >= 1.9.4
+test -e /dev/kvm && echo "KVM OK"
+```
+
+`fpm` (ruby gem), `rpm` and `cloud-image-utils` (which provides `cloud-localds`)
+are the three that are typically absent on a normal host and whose absence
+breaks the base-image build with a confusing error.
+
+You also need `git`, a text editor, and basic knowledge of bash and YAML.
 
 ---
 
-## 📁 Step 1: Create Directory Structure
+## 📁 Step 1: Clone the Repository and Initialise Submodules
+
+`apps-code/one-apps` is a **git submodule**. Without it,
+`apps-code/community-apps/packer/build.sh` is a dangling symlink (it points at
+`../../one-apps/packer/build.sh`) and `make <name>` fails on its first command.
+`one-apps/appliances/service.sh`, `packer/common.pkr.hcl` and
+`packer/postprocess.sh` are also missing without it.
 
 ```bash
 # Clone the repository
 git clone https://github.com/OpenNebula/marketplace-community.git
 cd marketplace-community
 
-# Create appliance directory (lowercase, no spaces)
+# REQUIRED: pull in the apps-code/one-apps submodule
+git submodule update --init --recursive
+
+# Sanity check: this must resolve, not dangle
+ls -l apps-code/community-apps/packer/build.sh
+test -f apps-code/one-apps/appliances/service.sh && echo "submodule OK"
+
+# Create the appliance directory (lowercase letters, digits and hyphens only)
 mkdir -p appliances/myapp
 cd appliances/myapp
 ```
 
 ---
 
-## 📝 Step 2: Create metadata.yaml
+## 📝 Step 2: Create the Appliance Metadata Files
 
-This file configures how Packer builds your appliance.
+Three separate files live in `appliances/myapp/`, and they are **not**
+interchangeable. None of them configures Packer — the build is configured in
+Step 5.
+
+| File | Consumed by | Purpose |
+|------|-------------|---------|
+| `metadata.yaml` | `lib/community/app_handler.rb` | certification-test metadata (`:app:` / `:one:` / `:infra:`) |
+| `context.yaml` | the test harness | default context values used by the tests |
+| `<UUID>.yaml` | the marketplace | the published appliance listing |
+
+### metadata.yaml
+
+`app_handler.rb` reads `config[:one][:template][:NAME]`,
+`config[:app][:context][:params]`, `config[:app][:context][:prefixed]` and
+`config[:infra][:disk_format]`, so the leading-colon (Ruby symbol) keys below
+are mandatory. Reference: `appliances/prowler/metadata.yaml`.
 
 ```bash
 nano metadata.yaml
 ```
 
-**Template:**
+```yaml
+---
+:app:
+  :name: myapp
+  :type: service
+  :os:
+    :type: linux
+    :base: ubuntu2204min
+  :hypervisor: KVM
+  :context:
+    :prefixed: true
+    :params:
+      :ONEAPP_CONTAINER_NAME: 'myapp-container'
+      :ONEAPP_CONTAINER_PORTS: '8080:8080'
+      :ONEAPP_CONTAINER_ENV: ''
+      :ONEAPP_CONTAINER_VOLUMES: ''
+
+:one:
+  :template:
+    NAME: base
+    TEMPLATE:
+      ARCH: x86_64
+      CONTEXT:
+        NETWORK: 'YES'
+        SET_HOSTNAME: "$NAME"
+        SSH_PUBLIC_KEY: "$USER[SSH_PUBLIC_KEY]"
+      CPU: '2'
+      CPU_MODEL:
+        MODEL: host-passthrough
+      GRAPHICS:
+        LISTEN: 0.0.0.0
+        TYPE: vnc
+      MEMORY: '2048'
+      NIC:
+        NETWORK: service
+      NIC_DEFAULT:
+        MODEL: virtio
+  :datastore_name: default
+  :timeout: '600'
+
+:infra:
+  :disk_format: qcow2
+  :apps_path: /var/tmp
+```
+
+`:os: :base:` must be one of the base images one-apps can build (see Step 6b),
+and it must match the `iso_url` you set in Step 5.
+
+### context.yaml
+
+```bash
+nano context.yaml
+```
+
+```yaml
+---
+ONEAPP_CONTAINER_NAME: 'myapp-container'
+ONEAPP_CONTAINER_PORTS: '8080:8080'
+ONEAPP_CONTAINER_ENV: ''
+ONEAPP_CONTAINER_VOLUMES: ''
+```
+
+### &lt;UUID&gt;.yaml — the marketplace listing
+
+The filename must be a UUID. Without this file the appliance never appears in
+the marketplace.
+
+```bash
+UUID=$(uuidgen)
+nano "${UUID}.yaml"
+```
 
 ```yaml
 ---
 name: 'MyApp'
-version: '1.0.0'
+version: 1.0.0-1
+one-apps_version: 7.0.0-0
 publisher: 'Your Name'
+publisher_email: 'your.email@domain.com'
 description: |-
-  MyApp description.
-  
-  This appliance runs MyApp in a Docker container on Ubuntu 22.04 LTS.
-  
-  **Access:**
-  - SSH: root@<vm-ip> (password: opennebula)
-  - Console: Auto-login as root
-  - Web UI: http://<vm-ip>:8080 (if applicable)
-  
-  **Features:**
-  - Docker container with automatic startup
-  - OpenNebula context integration
-  - Configurable via context variables
+  MyApp running in a Docker container on Ubuntu 22.04 LTS (Minimal).
 
+  **This appliance provides:**
+  - Docker Engine CE pre-installed and configured
+  - The MyApp container started automatically on first boot
+  - SSH **key-only** access (the key comes from OpenNebula contextualization;
+    there is no password login)
+  - Container name, ports, environment and volumes configurable at instantiation
 short_description: 'MyApp - Brief one-line description'
 tags:
-  - 'docker'
-  - 'myapp'
-  - 'ubuntu'
-format: 'qcow2'
-os-id: 'Ubuntu'
+- docker
+- myapp
+- ubuntu
+format: qcow2
+creation_time: 1785151582
+os-id: Ubuntu
 os-release: '22.04'
-os-arch: 'x86_64'
-hypervisor: 'KVM'
-opennebula_version: '6.0'
+os-arch: x86_64
+hypervisor: KVM
+opennebula_version: 6.10, 7.0
 opennebula_template:
   context:
     network: 'YES'
-    ssh_public_key: '$USER[SSH_PUBLIC_KEY]'
+    report_ready: 'YES'
+    set_hostname: "$NAME"
+    ssh_public_key: "$USER[SSH_PUBLIC_KEY]"
+    oneapp_container_name: "$ONEAPP_CONTAINER_NAME"
+    oneapp_container_ports: "$ONEAPP_CONTAINER_PORTS"
+    oneapp_container_env: "$ONEAPP_CONTAINER_ENV"
+    oneapp_container_volumes: "$ONEAPP_CONTAINER_VOLUMES"
   cpu: '2'
+  vcpu: '2'
   memory: '2048'
+  disk:
+    image: $FILE[IMAGE_ID]
+    image_uname: $USER[IMAGE_UNAME]
   graphics:
-    listen: '0.0.0.0'
-    type: 'VNC'
-logo: 'myapp.png'
-images:
-  - name: 'myapp'
-    url: ''
-    type: 'OS'
-    dev_prefix: 'vd'
-    driver: 'qcow2'
-    size: 8192
+    listen: 0.0.0.0
+    type: vnc
+  os:
+    arch: x86_64
+  user_inputs:
+    oneapp_container_name: 'M|text|Container name||myapp-container'
+    oneapp_container_ports: 'M|text|Container ports (host:container)||8080:8080'
+    oneapp_container_env: 'O|text|Environment variables (VAR=value,VAR2=value2)||'
+    oneapp_container_volumes: 'O|text|Volume mounts (/host:/container)||'
+  inputs_order: ONEAPP_CONTAINER_NAME,ONEAPP_CONTAINER_PORTS,ONEAPP_CONTAINER_ENV,ONEAPP_CONTAINER_VOLUMES
+logo: logos/myapp.png
 ```
 
-**Key fields to customize:**
-- `name` - Display name
-- `version` - Semantic version (1.0.0)
-- `publisher` - Your name
-- `description` - Full description with access info
-- `short_description` - One-line summary
-- `tags` - Searchable keywords
-- `cpu` / `memory` - Default VM resources
-- `size` - Disk size in MB (8192 = 8GB)
+> Everything under `appliances/` is linted by `.github/workflows/yamllint.yml`
+> with `.yamllint.yml`; keep lines free of trailing whitespace.
 
 ---
 
 ## 🔧 Step 3: Create appliance.sh
 
-This is the main installation script that runs during image build. **Use the exact structure from Phoenix RTOS/Node-RED** for proven reliability.
+This is the main installation script. It is **sourced** by the one-apps service
+manager at build and boot time, which then calls `service_install`,
+`service_configure` and `service_bootstrap`. Use `appliances/prowler/appliance.sh`
+as the reference implementation.
 
 ```bash
 nano appliance.sh
 ```
+
+### How this script is executed
+
+Do **not** add a `case "$1" in install|configure|bootstrap` dispatcher and do not
+run `appliance.sh` directly. The one-apps service manager
+(`/etc/one-appliance/service`, copied in from
+`apps-code/one-apps/appliances/service.sh`) **sources** this file and calls the
+lifecycle functions itself:
+
+```
+/etc/one-appliance/service install     ->  sources appliance.sh, calls service_install
+/etc/one-appliance/service configure   ->  sources appliance.sh, calls service_configure
+/etc/one-appliance/service bootstrap   ->  sources appliance.sh, calls service_bootstrap
+```
+
+A dispatcher at the bottom of the file would run the stage twice (once while
+being sourced, since positional parameters are inherited, and once from the
+framework), and running the script standalone fails immediately because helpers
+like `msg` only exist after the framework has sourced
+`/etc/one-appliance/lib/common.sh`.
+
+So the file must end after the last helper function — no `### Main execution`
+block, no `case`, no `exit 1`.
 
 **Template:**
 
@@ -148,18 +306,25 @@ ONE_SERVICE_PARAMS=(
 )
 
 # Configuration - CUSTOMIZE THESE
-DOCKER_IMAGE="your-docker-image:tag"
+# Always pin an immutable image tag. ':latest' is rejected: it makes the
+# appliance unreproducible and silently changes what ships.
+DOCKER_IMAGE="your-docker-image:1.2.3"
 DEFAULT_CONTAINER_NAME="myapp-container"
 DEFAULT_PORTS="8080:8080"
 DEFAULT_ENV_VARS=""
-DEFAULT_VOLUMES="/data:/data"
+# Leave empty unless the app really needs persistence. Mounting an empty host
+# directory over a path the image already populates hides the image's own
+# content and can break the application.
+DEFAULT_VOLUMES=""
 APP_NAME="MyApp"
 APPLIANCE_NAME="myapp"
+
+ONE_SERVICE_SETUP_DIR="/opt/one-appliance"   ### Install location. Required by bash helpers
 
 ### Appliance metadata ###############################################
 
 ONE_SERVICE_NAME='MyApp'
-ONE_SERVICE_VERSION=   #latest
+ONE_SERVICE_VERSION='1.2.3'
 ONE_SERVICE_BUILD=$(date +%s)
 ONE_SERVICE_SHORT_DESCRIPTION='MyApp Docker Container Appliance'
 ONE_SERVICE_DESCRIPTION='MyApp running in Docker container'
@@ -193,7 +358,7 @@ service_install()
     apt-get update
     apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 
-    # Enable and start Docker
+    # Enable Docker (it is started by systemd on the deployed VM)
     systemctl enable docker
     systemctl start docker
 
@@ -201,53 +366,22 @@ service_install()
     msg info "Pulling Docker image: $DOCKER_IMAGE"
     docker pull "$DOCKER_IMAGE"
 
-    # Configure console auto-login
-    systemctl stop unattended-upgrades 2>/dev/null || true
-    systemctl disable unattended-upgrades 2>/dev/null || true
-    apt-get install -y mingetty
-
-    # TTY1 auto-login
-    mkdir -p /etc/systemd/system/getty@tty1.service.d
-    cat > /etc/systemd/system/getty@tty1.service.d/override.conf << 'CONSOLE_EOF'
-[Service]
-ExecStart=
-ExecStart=-/sbin/agetty --noissue --autologin root %I \$TERM
-Type=idle
-CONSOLE_EOF
-
-    # Serial console auto-login
-    mkdir -p /etc/systemd/system/serial-getty@ttyS0.service.d
-    cat > /etc/systemd/system/serial-getty@ttyS0.service.d/override.conf << 'SERIAL_EOF'
-[Service]
-ExecStart=
-ExecStart=-/sbin/agetty --noissue --autologin root -s %I 115200,38400,9600 vt220
-SERIAL_EOF
-
-    # Create welcome message
-    cat > /etc/motd << 'MOTD_EOF'
-###############################################################################
-#                                                                             #
-#                    Welcome to MyApp Appliance                               #
-#                                                                             #
-###############################################################################
-
-Docker container: myapp-container
-Access: http://<vm-ip>:8080
-
-Useful commands:
-  - docker ps                    # Check container status
-  - docker logs myapp-container  # View container logs
-  - docker restart myapp-container  # Restart container
-
-MOTD_EOF
-
-    # Set root password
-    msg info "Setting root password to 'opennebula'"
-    echo "root:opennebula" | chpasswd
-
-    # Enable SSH password authentication
-    sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
-    sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+    # NOTE: do NOT set a root password and do NOT enable password SSH here.
+    #
+    # The deployed appliance is SSH-KEY-ONLY. one-context injects
+    # SSH_PUBLIC_KEY at instantiation; packer/myapp/81-configure-ssh.sh sets
+    # `PasswordAuthentication no` / `PermitRootLogin without-password` before
+    # the image is finalized, and packer/postprocess.sh runs
+    # `virt-sysprep --root-password disabled`, which wipes any password set
+    # here anyway. The password 'opennebula' belongs ONLY to the transient,
+    # localhost-bound Packer build VM (see packer/myapp/gen_context) and must
+    # never reach the shipped image.
+    #
+    # Root auto-login on tty1/ttyS0 is likewise omitted: anyone with VNC
+    # access to the VM would get an unauthenticated root shell.
+    #
+    # Do not write /etc/motd either - the one-apps service manager owns it and
+    # uses it to report the appliance status ("All set and ready to serve").
 
     msg info "${APP_NAME} installation completed"
 }
@@ -274,8 +408,8 @@ setup_app_container()
     msg info "Container configuration:"
     msg info "  Name: $container_name"
     msg info "  Ports: $container_ports"
-    msg info "  Environment: $container_env"
     msg info "  Volumes: $container_volumes"
+    # Do not log $container_env: it commonly carries secrets.
 
     # Stop and remove existing container if it exists
     if docker ps -a --format '{{.Names}}' | grep -q "^${container_name}$"; then
@@ -305,12 +439,24 @@ setup_app_container()
     # Parse volume mounts
     local volume_args=""
     if [ -n "$container_volumes" ]; then
+        # The UID/GID the image runs as, so a freshly created host directory is
+        # writable by an unprivileged container.
+        local image_uid image_gid
+        image_uid=$(docker image inspect -f '{{.Config.User}}' "$DOCKER_IMAGE" | cut -d: -f1)
+        image_gid=$(docker image inspect -f '{{.Config.User}}' "$DOCKER_IMAGE" | cut -d: -f2)
+        [ -n "$image_uid" ] || image_uid=0
+        [ -n "$image_gid" ] || image_gid="$image_uid"
+
         IFS=',' read -ra VOL_ARRAY <<< "$container_volumes"
         for vol in "${VOL_ARRAY[@]}"; do
-            local host_path=$(echo "$vol" | cut -d':' -f1)
-            mkdir -p "$host_path"
-            # Set ownership to 1000:1000 (common for Docker containers)
-            chown -R 1000:1000 "$host_path" 2>/dev/null || true
+            local host_path
+            host_path=$(echo "$vol" | cut -d':' -f1)
+            # Only touch directories we create ourselves; never chown a
+            # pre-existing host directory.
+            if [ ! -e "$host_path" ]; then
+                mkdir -p "$host_path"
+                chown -R "${image_uid}:${image_gid}" "$host_path" 2>/dev/null || true
+            fi
             volume_args="$volume_args -v $vol"
         done
     fi
@@ -334,26 +480,6 @@ setup_app_container()
         return 1
     fi
 }
-
-### Main execution ###################################################
-
-msg info "Starting ${APP_NAME} appliance setup"
-
-case "${1:-}" in
-    install)
-        service_install
-        ;;
-    configure)
-        service_configure
-        ;;
-    bootstrap)
-        service_bootstrap
-        ;;
-    *)
-        echo "Usage: $0 {install|configure|bootstrap}"
-        exit 1
-        ;;
-esac
 ```
 
 **Make it executable:**
@@ -380,17 +506,24 @@ MyApp description and features.
 ## Quick Start
 
 1. Deploy the appliance from OpenNebula Marketplace
-2. Access via SSH: `ssh root@<vm-ip>` (password: opennebula)
+2. Access via SSH: `ssh root@<vm-ip>` — **key-only**; the key is injected by
+   OpenNebula contextualization from `$USER[SSH_PUBLIC_KEY]`. There is no
+   password login.
 3. Access web interface: `http://<vm-ip>:8080`
 
 ## Configuration
 
-Configure the container via OpenNebula context variables:
+Configure the container via OpenNebula context variables (set them at
+instantiation, not in the image):
 
 - `ONEAPP_CONTAINER_NAME` - Container name (default: myapp-container)
 - `ONEAPP_CONTAINER_PORTS` - Port mappings (default: 8080:8080)
-- `ONEAPP_CONTAINER_ENV` - Environment variables (comma-separated)
-- `ONEAPP_CONTAINER_VOLUMES` - Volume mappings (comma-separated)
+- `ONEAPP_CONTAINER_ENV` - Environment variables, comma-separated `VAR=value`
+  (use this for secrets; they are never baked into the image)
+- `ONEAPP_CONTAINER_VOLUMES` - Volume mappings, comma-separated
+  `/host/path:/container/path`. Leave empty unless you really need
+  persistence: mounting an empty host directory over a path the image already
+  populates hides the image's own content and can break the application.
 
 ## Support
 
@@ -410,166 +543,494 @@ nano CHANGELOG.md
 
 ### Added
 - Initial release
-- Docker container with automatic startup
-- OpenNebula context integration
-- SSH and console access
+- Docker container started by service_bootstrap via one-context
+- OpenNebula context integration (ONEAPP_CONTAINER_*)
+- SSH key-only access
 ```
 
-### tests/tests.yaml
+### tests.yaml (appliance root) and tests/
+
+`lib/community/app_readiness.rb` loads `appliances/myapp/tests.yaml` — at the
+appliance root, **not** inside `tests/` — and expects a YAML *sequence of rspec
+filenames*, which it runs from `appliances/myapp/tests/`. A `tests:` mapping of
+shell commands is not read by anything.
 
 ```bash
 mkdir -p tests
-nano tests/tests.yaml
+
+cat > tests.yaml <<'EOF'
+---
+- 00-myapp_basic.rb
+EOF
+
+nano tests/00-myapp_basic.rb
 ```
 
-```yaml
----
-tests:
-  - name: "Container Running"
-    command: "docker ps --filter name=myapp-container --format '{{.Status}}' | grep -q Up"
-    expected_exit_code: 0
-  
-  - name: "SSH Access"
-    command: "systemctl is-active ssh"
-    expected_output: "active"
-  
-  - name: "Docker Service"
-    command: "systemctl is-active docker"
-    expected_output: "active"
+```ruby
+require_relative '../../../lib/community/app_handler'
+
+describe 'Appliance Certification' do
+    include_context('vm_handler')
+
+    it 'docker service is running' do
+        result = @info[:vm].ssh('systemctl is-active docker')
+        expect(result.exitstatus).to eq(0)
+        expect(result.stdout.strip).to eq('active')
+    end
+
+    it 'myapp container is up' do
+        start_time = Time.now
+        timeout = 240
+
+        loop do
+            result = @info[:vm].ssh("docker ps --filter name=myapp-container --format '{{.Status}}'")
+            break if result.success? && result.stdout.include?('Up')
+            raise "container not up within #{timeout}s" if Time.now - start_time > timeout
+            sleep 5
+        end
+    end
+
+    it 'one-apps reports the service as ready' do
+        result = @info[:vm].ssh('cat /etc/motd')
+        expect(result.stdout).to include('All set and ready to serve')
+    end
+end
 ```
 
+Run them from the frontend:
+
+```bash
+cd lib/community
+./app_readiness.rb myapp
+```
+
+See `appliances/prowler/tests/00-prowler_basic.rb` for a full example. Do not
+use the minitest `class X < Test` style — `Test` is not defined in this harness
+and it fails with `NameError: uninitialized constant Test`.
+
 ---
 
-## 🏗️ Step 5: Create Packer Configuration
+## 🏗️ Step 5: Create the Packer Build Definition
+
+`make myapp` runs `apps-code/community-apps/packer/build.sh`, which does exactly this:
+
+```
+packer init packer/myapp
+packer build -force \
+  -var appliance_name=myapp -var version= \
+  -var input_dir=packer/myapp -var output_dir=build/myapp \
+  -var headless=true -var arch=x86_64 \
+  packer/myapp
+qemu-img convert -c -O qcow2 build/myapp/myapp export/myapp.qcow2
+```
+
+Three consequences you must respect:
+
+* every `-var` above must be **declared** in the directory, or Packer aborts with
+  `Undefined variable ... was set but was not declared`;
+* the image must be written to `var.output_dir` (never a hardcoded path),
+  because `build.sh` converts `build/myapp/myapp` into `export/myapp.qcow2`;
+* `packer build` runs with the working directory set to
+  `apps-code/community-apps`, so every `source`/`scripts` path in the HCL is
+  relative to **that** directory — not to `packer/myapp/`.
+
+The build does **not** install an OS from an ISO. It boots the prebuilt base
+image produced by one-apps (`../one-apps/export/ubuntu2204min.qcow2`) as a disk
+image and runs the one-apps appliance lifecycle inside it.
 
 ```bash
 cd ../../apps-code/community-apps
 mkdir -p packer/myapp
-cd packer/myapp
+```
+
+### common.pkr.hcl (symlink — required)
+
+Declares the `arch` / `arch_vars` variables that `build.sh` passes and pins the
+qemu plugin.
+
+```bash
+ln -sf ../../../one-apps/packer/common.pkr.hcl packer/myapp/common.pkr.hcl
+```
+
+### variables.pkr.hcl
+
+```hcl
+variable "appliance_name" {
+  type = string
+}
+
+variable "version" {
+  type = string
+}
+
+variable "input_dir" {
+  type = string
+}
+
+variable "output_dir" {
+  type = string
+}
+
+variable "headless" {
+  type    = bool
+  default = true
+}
+```
+
+### gen_context (build-time context ISO)
+
+`PASSWORD='opennebula'` here is the **Packer communicator credential for the
+transient, localhost-bound build VM only** — identical to
+`packer/example/gen_context`. It never reaches the exported image:
+`81-configure-ssh.sh` re-disables password SSH during the build and
+`packer/postprocess.sh` runs `virt-sysprep --root-password disabled`.
+
+```bash
+cat > packer/myapp/gen_context <<'GENEOF'
+#!/bin/bash
+set -eux -o pipefail
+
+SCRIPT=$(cat <<'MAINEND'
+rm -f /etc/ssh/sshd_config.d/*cloudimg*.conf
+sed -i 's/^#*PermitRootLogin.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+grep -q '^PermitRootLogin' /etc/ssh/sshd_config || echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
+grep -q '^PasswordAuthentication' /etc/ssh/sshd_config || echo 'PasswordAuthentication yes' >> /etc/ssh/sshd_config
+systemctl reload sshd || systemctl reload ssh || true
+echo "nameserver 1.1.1.1" > /etc/resolv.conf
+MAINEND
+)
+
+cat <<CTXEOF
+ETH0_METHOD='dhcp'
+NETWORK='YES'
+SET_HOSTNAME='myapp'
+PASSWORD='opennebula'
+ETH0_MAC='00:11:22:33:44:55'
+NETCFG_TYPE='netplan'
+START_SCRIPT_BASE64="$(echo "$SCRIPT" | base64 -w0)"
+CTXEOF
+GENEOF
+chmod +x packer/myapp/gen_context
+```
+
+> `NETCFG_TYPE` depends on the base OS: `netplan` for ubuntu2204*/ubuntu2404*,
+> `interfaces` for debian11/debian12, `nm` for alma8/alma9/rocky8/rocky9,
+> `scripts` for opensuse15.
+
+### 81-configure-ssh.sh (re-hardens sshd before export)
+
+```bash
+cat > packer/myapp/81-configure-ssh.sh <<'SSHEOF'
+#!/usr/bin/env bash
+exec 1>&2
+set -eux -o pipefail
+
+sed -i 's/^#*PasswordAuthentication.*/PasswordAuthentication no/'  /etc/ssh/sshd_config
+sed -i 's/^#*PermitRootLogin.*/PermitRootLogin without-password/' /etc/ssh/sshd_config
+sed -i 's/^#*UseDNS.*/UseDNS no/'                                 /etc/ssh/sshd_config
+grep -q '^PasswordAuthentication' /etc/ssh/sshd_config || echo 'PasswordAuthentication no' >> /etc/ssh/sshd_config
+grep -q '^PermitRootLogin'        /etc/ssh/sshd_config || echo 'PermitRootLogin without-password' >> /etc/ssh/sshd_config
+
+sync
+SSHEOF
+chmod +x packer/myapp/81-configure-ssh.sh
+```
+
+### 82-configure-context.sh
+
+```bash
+cat > packer/myapp/82-configure-context.sh <<'CTXSHEOF'
+#!/usr/bin/env bash
+exec 1>&2
+set -eux -o pipefail
+
+mv /etc/one-appliance/net-90-service-appliance /etc/one-context.d/
+mv /etc/one-appliance/net-99-report-ready      /etc/one-context.d/
+
+chown root:root /etc/one-context.d/*
+chmod u=rwx,go=rx /etc/one-context.d/*
+
+# NetworkManager netplan files written during the build conflict with
+# one-context's 50-one-context.yaml at runtime and stop eth0 getting an IP.
+rm -f /etc/netplan/90-NM-*.yaml
+rm -f /etc/netplan/50-one-context.yaml
+
+sync
+CTXSHEOF
+chmod +x packer/myapp/82-configure-context.sh
 ```
 
 ### myapp.pkr.hcl
 
-```bash
-nano myapp.pkr.hcl
-```
-
 ```hcl
-packer {
-  required_plugins {
-    qemu = {
-      source  = "github.com/hashicorp/qemu"
-      version = "~> 1"
-    }
+source "null" "null" { communicator = "none" }
+
+# Build the build-time context ISO first
+build {
+  sources = ["source.null.null"]
+
+  provisioner "shell-local" {
+    inline = [
+      "mkdir -p ${var.input_dir}/context",
+      "${var.input_dir}/gen_context > ${var.input_dir}/context/context.sh",
+      "mkisofs -o ${var.input_dir}/${var.appliance_name}-context.iso -V CONTEXT -J -R ${var.input_dir}/context",
+    ]
   }
 }
 
 source "qemu" "myapp" {
-  vm_name          = "myapp"
-  iso_url          = "https://releases.ubuntu.com/22.04/ubuntu-22.04.5-live-server-amd64.iso"
-  iso_checksum     = "sha256:9bc6028870aef3f74f4e16b900008179e78b130e6b0b9a140635434a46aa98b0"
-  output_directory = "../../export"
-  disk_size        = "8G"
+  cpus        = 2
+  memory      = 2048
+  accelerator = "kvm"
+
+  # Base image built by: cd apps-code/one-apps && sudo make ubuntu2204min
+  iso_url      = "../one-apps/export/ubuntu2204min.qcow2"
+  iso_checksum = "none"
+
+  headless = var.headless
+
+  disk_image       = true
+  disk_cache       = "unsafe"
+  disk_interface   = "virtio"
+  net_device       = "virtio-net"
   format           = "qcow2"
-  accelerator      = "kvm"
-  headless         = true
-  
+  disk_compression = false
+  disk_size        = "8000"
+
+  output_directory = var.output_dir
+
+  qemuargs = [
+    ["-cpu", "host"],
+    ["-serial", "stdio"],
+    ["-cdrom", "${var.input_dir}/${var.appliance_name}-context.iso"],
+    # MAC addr must match ETH0_MAC from the context ISO
+    ["-netdev", "user,id=net0,hostfwd=tcp::{{ .SSHHostPort }}-:22"],
+    ["-device", "virtio-net-pci,netdev=net0,mac=00:11:22:33:44:55"]
+  ]
+
   ssh_username     = "root"
   ssh_password     = "opennebula"
-  ssh_timeout      = "30m"
-  
-  boot_wait        = "5s"
-  boot_command     = [
-    "<esc><wait>",
-    "linux /casper/vmlinuz autoinstall ds=nocloud-net;s=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ ---<enter>",
-    "initrd /casper/initrd<enter>",
-    "boot<enter>"
-  ]
-  
-  http_directory   = "http"
-  shutdown_command = "shutdown -P now"
+  ssh_timeout      = "900s"
+  shutdown_command = "poweroff"
+  vm_name          = var.appliance_name
 }
 
 build {
   sources = ["source.qemu.myapp"]
-  
+
+  # Revert the insecure SSH settings enabled by the build context
   provisioner "shell" {
+    scripts = ["${var.input_dir}/81-configure-ssh.sh"]
+  }
+
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -e"
     inline = [
-      "apt-get update",
-      "apt-get install -y cloud-init"
+      "install -o 0 -g 0 -m u=rwx,g=rx,o=   -d /etc/one-appliance/{,service.d/,lib/}",
+      "install -o 0 -g 0 -m u=rwx,g=rx,o=rx -d /opt/one-appliance/{,bin/}",
     ]
   }
-  
+
   provisioner "file" {
-    source      = "../../../../appliances/myapp/appliance.sh"
-    destination = "/tmp/appliance.sh"
-  }
-  
-  provisioner "shell" {
-    inline = [
-      "chmod +x /tmp/appliance.sh",
-      "/tmp/appliance.sh install",
-      "/tmp/appliance.sh configure"
+    sources = [
+      "../one-apps/appliances/scripts/net-90-service-appliance",
+      "../one-apps/appliances/scripts/net-99-report-ready",
     ]
+    destination = "/etc/one-appliance/"
+  }
+
+  # Bash helpers: this is where msg(), gen_password() etc. come from
+  provisioner "file" {
+    sources = [
+      "../../lib/common.sh",
+      "../../lib/functions.sh",
+    ]
+    destination = "/etc/one-appliance/lib/"
+  }
+
+  # The appliance service manager that sources your appliance.sh
+  provisioner "file" {
+    source      = "../one-apps/appliances/service.sh"
+    destination = "/etc/one-appliance/service"
+  }
+
+  # Your logic. It MUST be named appliance.sh
+  provisioner "file" {
+    sources     = ["../../appliances/myapp/appliance.sh"]
+    destination = "/etc/one-appliance/service.d/"
+  }
+
+  provisioner "shell" {
+    scripts = ["${var.input_dir}/82-configure-context.sh"]
+  }
+
+  # Run the install stage, then lock the root account password as the final
+  # in-guest step so the shipped image is SSH-key / context only and the
+  # build-time password cannot be used for console login.
+  provisioner "shell" {
+    inline_shebang = "/bin/bash -e"
+    inline         = ["/etc/one-appliance/service install", "passwd -l root", "sync"]
+  }
+
+  # virt-sysprep: strip machine-id, disable the root password, sparsify
+  post-processor "shell-local" {
+    execute_command = ["bash", "-c", "{{.Vars}} {{.Script}}"]
+    environment_vars = [
+      "OUTPUT_DIR=${var.output_dir}",
+      "APPLIANCE_NAME=${var.appliance_name}",
+    ]
+    scripts = ["packer/postprocess.sh"]
   }
 }
 ```
 
-### myapp.auto.pkrvars.hcl
+### .gitignore — transient artifacts only
+
+Do **not** ignore `myapp.pkr.hcl` or `gen_context`; they are the build
+definition and must be in your PR, otherwise nobody can rebuild your appliance.
 
 ```bash
-nano myapp.auto.pkrvars.hcl
-```
-
-```hcl
-# MyApp Packer Variables
+cat > packer/myapp/.gitignore <<'EOF'
+context/
+context.sh
+*-context.iso
+EOF
 ```
 
 ---
 
 ## 🎨 Step 6: Add Logo
 
-Create a 256x256 PNG logo:
+Create a 256x256 PNG logo and drop it in `logos/`:
 
 ```bash
-cd ../../../../logos
+# from apps-code/community-apps, go back to the repository root
+cd ../..
 # Add your myapp.png file here (256x256 pixels)
+cp /path/to/your-logo.png logos/myapp.png
+```
+
+Reference it from the marketplace listing as `logo: logos/myapp.png`.
+
+The remaining steps all start from the repository root.
+
+---
+
+## 🧱 Step 6b: Build the one-apps Base Image (required, once per base OS)
+
+The appliance build starts from a prebuilt base image at
+`apps-code/one-apps/export/<BASE_OS>.qcow2`. **`make <name>` in
+`community-apps` never builds it for you** — if the file is missing, the build
+fails immediately.
+
+```bash
+cd apps-code/one-apps
+sudo make ubuntu2204min          # ~2.5 minutes
+ls -l export/ubuntu2204min.qcow2 # must exist before Step 7
+cd ../..
+```
+
+This step also builds the one-context packages
+(`context-linux/generate-all.sh`), which is why the `fpm` ruby gem and `rpm` are
+in the prerequisites. Docker is *not* required for it.
+
+Supported base images (this is the value you must also use for `iso_url` in
+Step 5 and for `:os: :base:` in `metadata.yaml`):
+
+```
+ubuntu2204min  ubuntu2204  ubuntu2404min  ubuntu2404
+debian12       debian11    alma8          alma9
+rocky8         rocky9      opensuse15
 ```
 
 ---
 
-## 🔨 Step 7: Build the Appliance
+## 🔨 Step 7: Register the Service and Build
+
+`make <name>` only works for names listed in `SERVICES` in
+`apps-code/community-apps/Makefile.config`. The `Makefile` derives every target
+from that list (`$(SERVICES): %: packer-%`), so an unregistered name fails with
+`make: *** No rule to make target 'myapp'.  Stop.`
+
+### 7a. Register the appliance
 
 ```bash
-cd ../apps-code/community-apps
-make myapp
+cd apps-code/community-apps
+
+# Append 'myapp' to the SERVICES list (idempotent)
+grep -qE '^SERVICES :=.*( |:=)myapp( |$)' Makefile.config \
+  || sed -i 's/^\(SERVICES :=.*\)$/\1 myapp/' Makefile.config
+
+grep '^SERVICES' Makefile.config
 ```
 
-**Build time:** 15-20 minutes
+### 7b. Build
 
-**Output:** `export/myapp.qcow2`
+Still in `apps-code/community-apps`:
+
+```bash
+sudo make myapp
+```
+
+`make myapp` runs `packer/build.sh 'myapp' '' export/myapp.qcow2`, which does
+`packer init packer/myapp`, `packer build` with the `appliance_name`,
+`version`, `input_dir`, `output_dir`, `headless` and `arch` variables, and then
+`qemu-img convert -c -O qcow2 build/myapp/myapp export/myapp.qcow2`.
+
+**Build time:** ~2 minutes once the base image exists.
+
+**Output:** `apps-code/community-apps/export/myapp.qcow2`
+
+`Makefile.config` is part of the contribution — commit it with the rest (Step 10).
 
 ---
 
 ## 🧪 Step 8: Test Locally
 
-```bash
-cd export
+The exported image is a **contextualized cloud image**, not a standalone VM: it
+has no password (`virt-sysprep --root-password disabled` runs at the end of the
+build), no baked-in SSH key, and its `service_configure` / `service_bootstrap`
+stages are triggered by one-context. Booting it with plain `qemu-system-x86_64`
+and no CONTEXT CD-ROM leaves the container un-started and gives you no way in.
 
-# Start VM with QEMU
+Attach a context ISO instead:
+
+```bash
+cd export        # apps-code/community-apps/export
+
+mkdir -p /tmp/ctx
+cat > /tmp/ctx/context.sh <<EOF
+NETWORK='YES'
+ETH0_METHOD='dhcp'
+SET_HOSTNAME='myapp'
+SSH_PUBLIC_KEY="$(cat ~/.ssh/id_rsa.pub)"
+ONEAPP_CONTAINER_NAME='myapp-container'
+ONEAPP_CONTAINER_PORTS='8080:8080'
+ONEAPP_CONTAINER_ENV=''
+ONEAPP_CONTAINER_VOLUMES=''
+EOF
+genisoimage -o /tmp/myapp-context.iso -V CONTEXT -J -R /tmp/ctx
+
+cp myapp.qcow2 /tmp/myapp-test.qcow2
 qemu-system-x86_64 \
-  -enable-kvm \
-  -m 2048 \
-  -smp 2 \
-  -drive file=myapp.qcow2,format=qcow2 \
-  -net nic -net user,hostfwd=tcp::2222-:22,hostfwd=tcp::8080-:8080 \
-  -vnc :0
+  -enable-kvm -cpu host -m 2048 -smp 2 \
+  -drive file=/tmp/myapp-test.qcow2,format=qcow2,if=virtio \
+  -cdrom /tmp/myapp-context.iso \
+  -netdev user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::8080-:8080 \
+  -device virtio-net-pci,netdev=net0 \
+  -nographic
 ```
 
-Connect via VNC to `localhost:5900` and verify:
-- Console auto-login works
-- Docker container is running: `docker ps`
-- Application is accessible
+Then verify from another terminal (key authentication only — there is no
+password login):
+
+```bash
+ssh -p 2222 root@127.0.0.1 'docker ps'
+ssh -p 2222 root@127.0.0.1 'cat /etc/motd'   # expect "All set and ready to serve"
+ssh -p 2222 root@127.0.0.1 'docker logs myapp-container'
+curl -sI http://127.0.0.1:8080
+```
 
 ---
 
@@ -594,10 +1055,15 @@ oneimage create --name "MyApp" \
 
 ### Create VM Template
 
+`USER_INPUTS` only *collects* values into the template. They reach the guest
+only if `CONTEXT` references them with `$VAR` — omitting those lines is why
+operator input silently never arrives in the appliance.
+
 ```bash
 cat > myapp-template.txt << 'EOF'
 NAME = "MyApp"
 CPU = "2"
+VCPU = "2"
 MEMORY = "2048"
 
 DISK = [
@@ -616,14 +1082,20 @@ GRAPHICS = [
 
 CONTEXT = [
   NETWORK = "YES",
-  SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]"
+  REPORT_READY = "YES",
+  SET_HOSTNAME = "$NAME",
+  SSH_PUBLIC_KEY = "$USER[SSH_PUBLIC_KEY]",
+  ONEAPP_CONTAINER_NAME = "$ONEAPP_CONTAINER_NAME",
+  ONEAPP_CONTAINER_PORTS = "$ONEAPP_CONTAINER_PORTS",
+  ONEAPP_CONTAINER_ENV = "$ONEAPP_CONTAINER_ENV",
+  ONEAPP_CONTAINER_VOLUMES = "$ONEAPP_CONTAINER_VOLUMES"
 ]
 
 USER_INPUTS = [
-  ONEAPP_CONTAINER_NAME = "O|text|Container name||myapp-container",
-  ONEAPP_CONTAINER_PORTS = "O|text|Port mappings||8080:8080",
-  ONEAPP_CONTAINER_ENV = "O|text|Environment variables||",
-  ONEAPP_CONTAINER_VOLUMES = "O|text|Volume mappings||/data:/data"
+  ONEAPP_CONTAINER_NAME = "M|text|Container name||myapp-container",
+  ONEAPP_CONTAINER_PORTS = "M|text|Port mappings (host:container)||8080:8080",
+  ONEAPP_CONTAINER_ENV = "O|text|Environment variables (VAR=value,VAR2=value2)||",
+  ONEAPP_CONTAINER_VOLUMES = "O|text|Volume mappings (/host:/container)||"
 ]
 
 INPUTS_ORDER = "ONEAPP_CONTAINER_NAME,ONEAPP_CONTAINER_PORTS,ONEAPP_CONTAINER_ENV,ONEAPP_CONTAINER_VOLUMES"
@@ -631,6 +1103,10 @@ EOF
 
 onetemplate create myapp-template.txt
 ```
+
+> Container environment variables often carry secrets, which is why they are
+> supplied at instantiation through `ONEAPP_CONTAINER_ENV` rather than baked
+> into the image.
 
 ### Instantiate VM
 
@@ -647,8 +1123,12 @@ onevm show myapp-test | grep ETH0_IP
 ### Test Access
 
 ```bash
-# SSH access
-ssh root@<vm-ip>  # password: opennebula
+# SSH access (key-only: the key is injected by OpenNebula contextualization
+# from $USER[SSH_PUBLIC_KEY]; there is NO password login on the deployed VM)
+ssh root@<vm-ip>
+
+# Check the one-apps lifecycle finished
+cat /etc/motd            # expect "All set and ready to serve"
 
 # Check container
 docker ps
@@ -668,6 +1148,7 @@ docker logs myapp-container
 # Then clone your fork
 git clone https://github.com/YOUR_USERNAME/marketplace-community.git
 cd marketplace-community
+git submodule update --init --recursive
 
 # Create feature branch
 git checkout -b feature/add-myapp-appliance
@@ -678,13 +1159,20 @@ git checkout -b feature/add-myapp-appliance
 ```bash
 git add appliances/myapp/
 git add apps-code/community-apps/packer/myapp/
+# REQUIRED: without the SERVICES entry nobody can run `make myapp`
+git add apps-code/community-apps/Makefile.config
 git add logos/myapp.png
+
+# Sanity check: the build definition must actually be in the commit
+git status --short
+git check-ignore -v apps-code/community-apps/packer/myapp/myapp.pkr.hcl \
+  && echo "ERROR: myapp.pkr.hcl is gitignored - your PR would not build"
 
 git commit -m "Add MyApp appliance
 
-- Docker container with automatic startup
-- OpenNebula context integration
-- SSH and console access
+- Docker container started by service_bootstrap via one-context
+- OpenNebula context integration (ONEAPP_CONTAINER_*)
+- SSH key-only access
 - Web interface on port 8080"
 ```
 
@@ -706,27 +1194,28 @@ This PR adds a new appliance for MyApp, a [brief description].
 
 ## Features
 
-- Docker container with automatic startup
+- Docker container started on first boot by `service_bootstrap`
 - OpenNebula context integration
 - Configurable via context variables:
   - Container name
   - Port mappings
-  - Environment variables
+  - Environment variables (use this for secrets)
   - Volume mappings
 
 ## Testing
 
-- ✅ Built successfully with Packer
+- ✅ Built successfully with Packer (`sudo make myapp`)
 - ✅ Deployed to OpenNebula
 - ✅ Container starts automatically
-- ✅ SSH access works (password + keys)
-- ✅ Console auto-login works
+- ✅ SSH key access works (key-only; no password login, root password disabled by virt-sysprep)
+- ✅ `/etc/motd` reports "All set and ready to serve"
 - ✅ Application accessible on configured ports
 
 ## Files Added
 
-- `appliances/myapp/` - Appliance definition files
+- `appliances/myapp/` - Appliance definition, metadata, listing and tests
 - `apps-code/community-apps/packer/myapp/` - Packer build configuration
+- `apps-code/community-apps/Makefile.config` - `myapp` added to `SERVICES`
 - `logos/myapp.png` - Appliance logo
 
 ## Checklist
@@ -735,7 +1224,9 @@ This PR adds a new appliance for MyApp, a [brief description].
 - [x] Appliance tested on OpenNebula
 - [x] Documentation included (README.md)
 - [x] Logo added (256x256 PNG)
-- [x] Follows Phoenix RTOS/Node-RED structure
+- [x] Follows the one-apps service framework structure (see `appliances/prowler/` and `apps-code/community-apps/packer/prowler/`)
+- [x] Registered in `apps-code/community-apps/Makefile.config` SERVICES
+- [x] Docker image pinned to an immutable tag (not `:latest`)
 - [x] No sensitive information in files
 ```
 
@@ -743,26 +1234,58 @@ This PR adds a new appliance for MyApp, a [brief description].
 
 ## 🐛 Troubleshooting
 
-**Problem:** appliance.sh fails during build  
-**Solution:** Test script manually on Ubuntu 22.04 VM
+**Problem:** `make: *** No rule to make target 'myapp'. Stop.`
+**Solution:** `myapp` is not in `SERVICES` in
+`apps-code/community-apps/Makefile.config` (Step 7a).
 
-**Problem:** Container doesn't start  
-**Solution:** Check Docker logs: `docker logs container-name`
+**Problem:** `packer/build.sh: No such file or directory`
+**Solution:** The `apps-code/one-apps` submodule is not initialised. Run
+`git submodule update --init --recursive` (Step 1).
 
-**Problem:** SSH fails  
-**Solution:** Recreate VM template (OpenNebula context issue)
+**Problem:** Packer aborts with `Undefined variable ... was set but was not declared`
+**Solution:** `variables.pkr.hcl` or the `common.pkr.hcl` symlink is missing
+from `packer/myapp/` (Step 5).
 
-**Problem:** Build takes too long  
-**Solution:** Use local Ubuntu ISO mirror
+**Problem:** The build fails immediately looking for
+`../one-apps/export/ubuntu2204min.qcow2`
+**Solution:** Build the base image first: `cd apps-code/one-apps && sudo make ubuntu2204min`
+(Step 6b). `make <name>` never builds it for you.
+
+**Problem:** Container doesn't start
+**Solution:** Check Docker logs on the VM: `docker logs <container-name>`, and
+the appliance log with `journalctl -u one-context`.
+
+**Problem:** `Permission denied (publickey)` when SSHing to the deployed VM
+**Solution:** Expected if no key was injected. The appliance is key-only —
+make sure `SSH_PUBLIC_KEY` is in the template `CONTEXT` and that your user has
+`SSH_PUBLIC_KEY` set (`oneuser update <user>`).
+
+**Problem:** Operator-supplied `ONEAPP_CONTAINER_*` values are ignored
+**Solution:** The template's `CONTEXT` section is missing the
+`ONEAPP_CONTAINER_* = "$ONEAPP_CONTAINER_*"` lines. `USER_INPUTS` alone does
+not reach the guest (Step 9).
+
+**Problem:** The app serves nothing after mounting a volume
+**Solution:** You mounted an empty host directory over a path the image already
+populates. Leave `ONEAPP_CONTAINER_VOLUMES` empty unless you need persistence.
 
 ---
 
 ## 💡 Tips
 
-- **Follow the pattern** - Use the Phoenix RTOS/Node-RED structure (proven in production)
-- **Test locally first** - Test appliance.sh on a VM before building
-- **Use logging** - Add `msg info` statements for debugging
-- **Volume permissions** - Set correct ownership for non-root containers
+- **Follow the pattern** - Use `appliances/prowler/` plus
+  `apps-code/community-apps/packer/prowler/` as the reference for a Docker-based
+  community appliance
+- **Never run appliance.sh directly** - it is sourced by
+  `/etc/one-appliance/service`, which calls the lifecycle functions
+- **Pin image tags** - `:latest` is rejected; it makes the appliance
+  unreproducible
+- **Never mount the Docker socket** - `/var/run/docker.sock` is a container
+  escape vector and is rejected
+- **Use logging** - Add `msg info` statements for debugging, but never log
+  `ONEAPP_CONTAINER_ENV`, it can carry secrets
+- **Volume permissions** - only chown a host directory you created yourself;
+  never touch a pre-existing one
 - **Keep it simple** - Start with minimal features, add incrementally
 
 ---
@@ -770,8 +1293,8 @@ This PR adds a new appliance for MyApp, a [brief description].
 ## 📖 Additional Resources
 
 - [Automatic Appliance Guide](AUTOMATIC_APPLIANCE_GUIDE.md) - For quick generation
+- [one-apps build requirements](https://github.com/OpenNebula/one-apps/wiki/tool_reqs)
 - [OpenNebula Documentation](https://docs.opennebula.io/)
 - [Docker Hub](https://hub.docker.com/)
 - [Packer Documentation](https://www.packer.io/docs)
 - [OpenNebula Marketplace](https://marketplace.opennebula.io/)
-

--- a/docs/MANUAL_APPLIANCE_GUIDE.md
+++ b/docs/MANUAL_APPLIANCE_GUIDE.md
@@ -597,16 +597,39 @@ describe 'Appliance Certification' do
 end
 ```
 
-Run them from the frontend:
+Run them from the frontend, **as the `oneadmin` user**:
 
 ```bash
-cd lib/community
-./app_readiness.rb myapp
+# rspec is not part of the OpenNebula gem set; install it once
+sudo gem install --no-document rspec
+
+# the qcow2 must be readable by oneadmin (oned runs as oneadmin), so publish it
+# somewhere outside /root - :apps_path: in metadata.yaml points at /var/tmp
+sudo cp apps-code/community-apps/export/myapp.qcow2 /var/tmp/ && sudo chmod 644 /var/tmp/myapp.qcow2
+
+sudo -u oneadmin env IMAGES_URL=/var/tmp/ bash -c 'cd lib/community && mkdir -p results && ./app_readiness.rb myapp'
 ```
+
+Three things bite here if you get them wrong:
+
+- **Run as `oneadmin`, not root.** The harness reaches the VM with
+  `ssh root@<vm-ip>`, and the only key the VM trusts is the one contextualization
+  injected from `$USER[SSH_PUBLIC_KEY]` — oneadmin's. As root you get
+  `Permission denied (publickey)` and every example fails with
+  `reached timeout ... reachable?`.
+- **`IMAGES_URL` must point at a directory `oneadmin` can read.** The harness
+  creates the image from `${IMAGES_URL}myapp.qcow2`; a path under `/root` fails
+  with `Cannot parse image SIZE: ... (Permission denied)`.
+- **The harness needs a VM template named `base`.** `defaults.yaml` sets
+  `:template: base`, and `app_handler.rb` instantiates it with `--disk <image>`
+  and the context built from your `metadata.yaml` `:params:`. Create one with
+  the CPU/memory/NIC/graphics your appliance needs before running the tests.
 
 See `appliances/prowler/tests/00-prowler_basic.rb` for a full example. Do not
 use the minitest `class X < Test` style — `Test` is not defined in this harness
-and it fails with `NameError: uninitialized constant Test`.
+and it fails with `NameError: uninitialized constant Test`. Make each check
+retry: the VM answers SSH before the appliance has finished bootstrapping, so a
+single-shot `expect(...)` on `systemctl is-active docker` is racy.
 
 ---
 
@@ -653,6 +676,14 @@ ln -sf ../../../one-apps/packer/common.pkr.hcl packer/myapp/common.pkr.hcl
 ```
 
 ### variables.pkr.hcl
+
+`packer/build.sh` always passes `appliance_name`, `version`, `input_dir`,
+`output_dir` and `headless` on the command line, so these variables **must** be
+declared or the build stops with `Error: Undefined -var variable`.
+
+```bash
+nano packer/myapp/variables.pkr.hcl
+```
 
 ```hcl
 variable "appliance_name" {
@@ -762,6 +793,14 @@ chmod +x packer/myapp/82-configure-context.sh
 ```
 
 ### myapp.pkr.hcl
+
+This is the build definition `make myapp` runs. The file name must match the
+appliance name, because `packer/build.sh` loads every `*.pkr.hcl` in
+`packer/myapp/`.
+
+```bash
+nano packer/myapp/myapp.pkr.hcl
+```
 
 ```hcl
 source "null" "null" { communicator = "none" }

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,80 @@
 
 Welcome to the OpenNebula appliance creation documentation! This guide will help you create Docker-based appliances for the OpenNebula Community Marketplace.
 
+> **Read the Prerequisites section below first.** Cloning the repository,
+> initializing the `one-apps` submodule and building the base OS image once are mandatory:
+> without them `make <appliance>` fails immediately, no matter which guide you follow.
+
+---
+
+## 🛠️ Prerequisites
+
+The image build runs Packer + QEMU/KVM and chroots into the guest, so it must run
+**on a Linux host, as root**, with hardware virtualization available:
+
+- Linux (Ubuntu 22.04+ recommended). macOS/BSD will **not** work — the generator uses GNU `sed -i`.
+- `root` privileges (the build chroots) and access to `/dev/kvm`
+- At least 8 GB RAM and 40 GB free disk
+- Packer >= 1.9.4
+
+### 1. Clone the repository and initialize the submodule
+
+```bash
+# Clone the repository AND initialise the one-apps submodule (without this,
+# apps-code/community-apps/packer/build.sh is a dangling symlink and every build fails)
+git clone https://github.com/OpenNebula/marketplace-community.git
+cd marketplace-community
+git submodule update --init --recursive
+```
+
+### 2. Install the build prerequisites
+
+Full authoritative list: <https://github.com/OpenNebula/one-apps/wiki/tool_reqs>
+
+```bash
+# Install the build prerequisites (Ubuntu/Debian).
+sudo apt update
+sudo apt install -y make ruby rpm rsync genisoimage cloud-utils cloud-image-utils \
+                    qemu-utils qemu-system-x86 libguestfs-tools
+sudo gem install --no-document backports fpm
+```
+
+`fpm` (a Ruby gem), `rpm` and `cloud-image-utils` (which provides `cloud-localds`) are **not**
+present on a stock Ubuntu host, and the one-apps context-package build fails without them.
+
+Packer >= 1.9.4 is **not** in the Ubuntu archive — install HashiCorp's package:
+
+```bash
+wget -O- https://apt.releases.hashicorp.com/gpg | \
+  sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+  sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install -y packer
+```
+
+### 3. Build the base OS image (once)
+
+Every generated `<name>.pkr.hcl` boots the base image from `../one-apps/export/<BASE_OS>.qcow2`,
+and `make <appliance>` in `apps-code/community-apps` never builds it for you, so it must exist
+first:
+
+```bash
+# Build the base OS image ONCE (~2.5 minutes). Every appliance is built on top of it.
+cd apps-code/one-apps
+sudo make ubuntu2204min          # -> apps-code/one-apps/export/ubuntu2204min.qcow2
+cd ../..
+```
+
+If you set a different `BASE_OS` in your `.env`, build that base image instead
+(`ubuntu2204`, `ubuntu2404min`, `ubuntu2404`, `debian12`, `debian11`, `alma8`, `alma9`,
+`rocky8`, `rocky9`, `opensuse15`).
+
+> The generator's interactive build prompt will initialize the submodule and build the base
+> image for you *if you answer `y`* at a real terminal. With `--no-build`, in a non-interactive
+> session (CI, `ssh host 'bash -s'`), or when you run `make <appliance>` yourself, it will not —
+> do steps 1-3 above first.
+
 ---
 
 ## 📚 Available Guides
@@ -12,19 +86,28 @@ Choose the approach that best fits your needs:
 
 **Best for:** Quick appliance creation, beginners, standard Docker containers
 
-**Time:** ~5 minutes for generation + 15-20 minutes for building
+**Time:** seconds to generate + ~2 minutes to build the appliance image
+(plus a one-time ~2.5 minute base OS image build)
 
 **Features:**
-- ✅ Automated file generation from simple configuration
-- ✅ Proven Phoenix RTOS/Node-RED structure
-- ✅ Built-in examples (NGINX, Node-RED, PostgreSQL, Redis)
-- ✅ Automatic build integration
+- ✅ Automated file generation from a simple `.env` configuration
+- ✅ Produces the complete buildable layout: `appliances/<name>/`, `apps-code/community-apps/packer/<name>/`,
+  and the `SERVICES` registration in `apps-code/community-apps/Makefile.config`
+- ✅ Working examples in `examples/` (NGINX, PostgreSQL, Redis, Node-RED) — every `DOCKER_IMAGE`
+  is pinned to a fixed tag, because the generator rejects `:latest` and untagged images
+- ✅ Generates the community RSpec test skeleton
 - ✅ Minimal configuration required
 
 **Quick Start:**
+
+> Finish the **Prerequisites** section above first — submodule init and the base image
+> build are mandatory.
+
 ```bash
 cd docs/automatic-appliance-tutorial
+
 cat > myapp.env << 'EOF'
+# DOCKER_IMAGE must be pinned: ':latest' and untagged images are rejected
 DOCKER_IMAGE="nginx:alpine"
 APPLIANCE_NAME="nginx"
 APP_NAME="NGINX"
@@ -33,10 +116,72 @@ PUBLISHER_EMAIL="your@email.com"
 DEFAULT_PORTS="80:80"
 APP_PORT="80"
 WEB_INTERFACE="true"
+# Optional, default ubuntu2204min. One of: ubuntu2204min ubuntu2204 ubuntu2404min
+# ubuntu2404 debian12 debian11 alma8 alma9 rocky8 rocky9 opensuse15
+BASE_OS="ubuntu2204min"
 EOF
 
-./generate-docker-appliance.sh myapp.env
+# Generate the appliance files.
+#   --no-build  skip the interactive "build now?" prompt (use for CI/scripted runs)
+#   --force     regenerate over an existing appliance of the same name; without it
+#               the generator refuses to overwrite and exits 1
+sudo ./generate-docker-appliance.sh myapp.env --no-build
+
+# Build the image (~2 min). The make target is APPLIANCE_NAME.
+cd ../../apps-code/community-apps
+sudo make nginx
+# -> apps-code/community-apps/export/nginx.qcow2
 ```
+
+Ready-made configs live in `docs/automatic-appliance-tutorial/examples/`, e.g.
+
+```bash
+cd docs/automatic-appliance-tutorial
+sudo ./generate-docker-appliance.sh examples/nginx.env --no-build
+```
+
+**Full generator CLI:**
+
+```text
+./generate-docker-appliance.sh <config.env> [--no-build] [--force] [-h|--help]
+
+  --no-build   Do not offer to build after generating. Required for
+               non-interactive/CI use.
+  --force      Regenerate over an existing appliance of the same name; the previous
+               appliance directory is wiped first. Without it the generator refuses
+               to overwrite and exits 1.
+  -h, --help   Show usage and exit.
+```
+
+`BASE_OS` is not a flag — it is set **inside** the `.env` file and defaults to
+`ubuntu2204min`. Supported values: `ubuntu2204min`, `ubuntu2204`, `ubuntu2404min`,
+`ubuntu2404`, `debian12`, `debian11`, `alma8`, `alma9`, `rocky8`, `rocky9`, `opensuse15`.
+
+**Files the generator produces:**
+
+```text
+appliances/<name>/appliance.sh
+appliances/<name>/metadata.yaml
+appliances/<name>/<uuid>.yaml
+appliances/<name>/context.yaml
+appliances/<name>/README.md
+appliances/<name>/CHANGELOG.md
+appliances/<name>/tests.yaml
+appliances/<name>/tests/00-<name>_basic.rb
+apps-code/community-apps/packer/<name>/<name>.pkr.hcl
+apps-code/community-apps/packer/<name>/variables.pkr.hcl
+apps-code/community-apps/packer/<name>/common.pkr.hcl   (symlink into one-apps)
+apps-code/community-apps/packer/<name>/gen_context
+apps-code/community-apps/packer/<name>/81-configure-ssh.sh
+apps-code/community-apps/packer/<name>/82-configure-context.sh
+apps-code/community-apps/packer/<name>/postprocess.sh
+apps-code/community-apps/packer/<name>/.gitignore
+(modified) apps-code/community-apps/Makefile.config
+```
+
+Everything above, **including the `Makefile.config` change**, must be part of your pull
+request — otherwise `make <name>` is not a valid target for reviewers. The only exceptions
+are the `.gitignore`d transient build artifacts (`context/`, `context.sh`, `*-context.iso`).
 
 ---
 
@@ -44,7 +189,7 @@ EOF
 
 **Best for:** Custom appliances, advanced users, special requirements
 
-**Time:** ~30-45 minutes for creation + 15-20 minutes for building
+**Time:** ~30-45 minutes of authoring + ~2 minutes to build the appliance image
 
 **Features:**
 - ✅ Complete control over all files
@@ -55,11 +200,31 @@ EOF
 
 **Quick Start:**
 ```bash
-mkdir -p appliances/myapp
-cd appliances/myapp
-# Create metadata.yaml, appliance.sh, README.md, etc.
-# See the manual guide for detailed instructions
+# NOTE: an appliance directory alone is NOT buildable. `make <name>` also requires:
+#   apps-code/community-apps/packer/<name>/<name>.pkr.hcl
+#   apps-code/community-apps/packer/<name>/variables.pkr.hcl
+#   apps-code/community-apps/packer/<name>/{gen_context,81-configure-ssh.sh,82-configure-context.sh,postprocess.sh}
+#   apps-code/community-apps/packer/<name>/common.pkr.hcl -> ../../../one-apps/packer/common.pkr.hcl
+#   <name> appended to the SERVICES := line in apps-code/community-apps/Makefile.config
+#
+# Recommended even for custom appliances: generate a buildable skeleton first,
+# then edit it by hand.
+cd docs/automatic-appliance-tutorial
+sudo ./generate-docker-appliance.sh myapp.env --no-build
+$EDITOR ../../appliances/myapp/appliance.sh
+$EDITOR ../../apps-code/community-apps/packer/myapp/myapp.pkr.hcl
 ```
+
+> ⚠️ **Known gap in [MANUAL_APPLIANCE_GUIDE.md](MANUAL_APPLIANCE_GUIDE.md):** its Step 5
+> describes a standalone, ISO-based `myapp.pkr.hcl` that does not declare the variables
+> `packer/build.sh` passes (`appliance_name`, `version`, `input_dir`, `output_dir`,
+> `headless`, `arch`), and the guide never registers the appliance in the
+> `SERVICES :=` line of `apps-code/community-apps/Makefile.config`. Its Step 7 `make myapp`
+> therefore cannot work as written. Step 5 also has you write a
+> `myapp.auto.pkrvars.hcl`; no such file exists in a real appliance — variables are
+> declared in `variables.pkr.hcl` and passed in by `packer/build.sh`. Generate the
+> skeleton as shown above and edit it instead of hand-writing the Packer template
+> from scratch.
 
 ---
 
@@ -71,12 +236,13 @@ cd appliances/myapp
 | Standard Docker container | **Automatic** |
 | Need quick results | **Automatic** |
 | Want to learn the structure | **Automatic** (then study generated files) |
-| Need custom installation steps | **Manual** |
+| Need custom installation steps | **Automatic**, then edit the generated files |
 | Complex system requirements | **Manual** |
 | Non-standard Docker setup | **Manual** |
 | Want full control | **Manual** |
 
-**Pro Tip:** Even if you need customization, start with the automatic generator to get a working base, then modify the generated files!
+**Pro Tip:** Even if you need customization, start with the automatic generator to get a
+buildable base, then modify the generated files!
 
 ---
 
@@ -84,13 +250,25 @@ cd appliances/myapp
 
 Both guides help you create:
 
-- **VM Image (QCOW2)** - Ubuntu 22.04 LTS with Docker pre-installed
-- **Docker Container** - Your application running in a container
-- **Automatic Startup** - Container starts automatically on VM boot
-- **SSH Access** - Password (opennebula) and key authentication
-- **Console Access** - Auto-login to root user
-- **OpenNebula Context** - Runtime configuration via context variables
-- **VNC Access** - Graphical console access
+- **VM Image (QCOW2)** - Base OS with Docker Engine CE installed at build time.
+  Default `ubuntu2204min`; set `BASE_OS` in the `.env` to one of `ubuntu2204min`,
+  `ubuntu2204`, `ubuntu2404min`, `ubuntu2404`, `debian12`, `debian11`, `alma8`,
+  `alma9`, `rocky8`, `rocky9`, `opensuse15`
+- **Docker Container** - Your image, pulled at build time and baked into the qcow2
+- **Automatic Startup** - Container started on boot with hardening flags:
+  `--security-opt=no-new-privileges --cap-drop=ALL --cap-add=CHOWN,SETUID,SETGID,NET_BIND_SERVICE --pids-limit=512 --memory=1g`
+- **SSH Access** - **Key-only.** The key is injected from the OpenNebula context variable
+  `SSH_PUBLIC_KEY`; the deployed VM has **no password login** (root's password is locked and
+  sshd is configured with `PasswordAuthentication no` / `PermitRootLogin prohibit-password`).
+  The `opennebula` password is only the Packer communicator credential on the transient,
+  localhost-bound build VM and never reaches the shipped image.
+- **Console Access** - Auto-login to root on tty1 and on the serial console
+- **OpenNebula Context** - Runtime configuration via `ONEAPP_CONTAINER_NAME`,
+  `ONEAPP_CONTAINER_PORTS`, `ONEAPP_CONTAINER_ENV` and `ONEAPP_CONTAINER_VOLUMES`.
+  Environment variables may hold secrets, so they are supplied at instantiation and are
+  never baked into the image. Any hand-written VM template must pass these four through in
+  its `CONTEXT` section.
+- **VNC Access** - Graphical console via OpenNebula Sunstone
 
 ---
 
@@ -98,42 +276,86 @@ Both guides help you create:
 
 | Feature | Automatic | Manual |
 |---------|-----------|--------|
-| **Time to create** | 5 minutes | 30-45 minutes |
+| **Time to create** | Seconds | 30-45 minutes |
 | **Difficulty** | Easy | Moderate |
 | **Customization** | Limited | Full |
 | **Learning curve** | Low | Medium |
 | **Best for** | Standard containers | Custom requirements |
-| **Files generated** | All files | You create all files |
-| **Examples included** | Yes (4 examples) | Template provided |
-| **Build integration** | Yes | Manual |
+| **Files generated** | All files, including the packer dir and Makefile.config entry | You create all files |
+| **Examples included** | Yes (4 working: nginx, postgres, redis, nodered) | Template provided |
+| **Build integration** | Yes | You must register the appliance yourself |
 
 ---
 
 ## 📦 Example Appliances
 
-Both guides can create appliances for:
+The four `.env` files shipped in `docs/automatic-appliance-tutorial/examples/` have all been
+built and booted:
 
-- **Web Servers** - NGINX, Apache, Caddy
-- **Databases** - PostgreSQL, MySQL, MongoDB, Redis
-- **Development Tools** - Node-RED, Jupyter, VS Code Server
-- **Monitoring** - Grafana, Prometheus, Netdata
-- **Automation** - n8n, Airflow, Jenkins
-- **And more!** - Any Docker container
+| Example | `DOCKER_IMAGE` |
+|---------|----------------|
+| `nginx.env` | `nginx:alpine` |
+| `postgres.env` | `postgres:15` |
+| `redis.env` | `redis:alpine` |
+| `nodered.env` | `nodered/node-red:5.0.1` |
+
+The same approach works for other containerized software — web servers, databases,
+development tools, monitoring stacks, automation platforms — subject to two rules the
+generator enforces:
+
+- **Pin the image.** `:latest` and untagged images are rejected; use a fixed tag or a digest.
+- **No Docker socket mounts.** Mounting `/var/run/docker.sock` into the container is rejected
+  as a container-escape vector.
+
+> **Volumes:** when the appliance creates a *new* host directory for a volume mount, it chowns
+> that directory to the UID/GID the container image runs as, which is what makes volumes work
+> for images running unprivileged. A pre-existing host directory is never touched. Do not mount
+> empty host directories over paths the image ships content in (that is why `examples/nginx.env`
+> sets `DEFAULT_VOLUMES=""` — mounting over `/etc/nginx/conf.d` removed `default.conf` and nginx
+> served nothing).
 
 ---
 
-## 🛠️ Prerequisites
+## ✅ End-to-end example
 
-Both guides require:
-
-- Linux system (Ubuntu 22.04+ recommended)
-- Git
-- Packer (for building images)
-- QEMU/KVM (for building images)
+The full sequence, from a clean Linux host to a booting appliance image:
 
 ```bash
+# 1. Clone the repository AND initialise the one-apps submodule (without this,
+#    apps-code/community-apps/packer/build.sh is a dangling symlink and every build fails)
+git clone https://github.com/OpenNebula/marketplace-community.git
+cd marketplace-community
+git submodule update --init --recursive
+
+# 2. Install the build prerequisites (Ubuntu/Debian).
+#    Full authoritative list: https://github.com/OpenNebula/one-apps/wiki/tool_reqs
 sudo apt update
-sudo apt install -y git qemu-kvm qemu-utils
+sudo apt install -y make ruby rpm rsync genisoimage cloud-utils cloud-image-utils \
+                    qemu-utils qemu-system-x86 libguestfs-tools
+sudo gem install --no-document backports fpm
+
+#    Packer >= 1.9.4 is NOT in the Ubuntu archive - install HashiCorp's package:
+wget -O- https://apt.releases.hashicorp.com/gpg | \
+  sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] \
+https://apt.releases.hashicorp.com $(lsb_release -cs) main" | \
+  sudo tee /etc/apt/sources.list.d/hashicorp.list
+sudo apt update && sudo apt install -y packer
+
+# 3. Build the base OS image ONCE (~2.5 minutes). Every appliance is built on top of it,
+#    and 'make <name>' never builds it for you.
+cd apps-code/one-apps
+sudo make ubuntu2204min          # -> apps-code/one-apps/export/ubuntu2204min.qcow2
+cd ../..
+
+# 4. Generate the appliance from its .env description
+cd docs/automatic-appliance-tutorial
+sudo ./generate-docker-appliance.sh examples/nginx.env --no-build
+cd ../..
+
+# 5. Build the appliance image (~2 minutes)
+cd apps-code/community-apps
+sudo make nginx                  # -> apps-code/community-apps/export/nginx.qcow2
 ```
 
 ---
@@ -141,8 +363,8 @@ sudo apt install -y git qemu-kvm qemu-utils
 ## 📚 Additional Resources
 
 - [OpenNebula Documentation](https://docs.opennebula.io/)
+- [one-apps build requirements](https://github.com/OpenNebula/one-apps/wiki/tool_reqs)
 - [OpenNebula Marketplace](https://marketplace.opennebula.io/)
 - [Docker Hub](https://hub.docker.com/)
 - [Packer Documentation](https://www.packer.io/docs)
 - [OpenNebula Community Forum](https://forum.opennebula.io/)
-

--- a/docs/automatic-appliance-tutorial/appliance-wizard.sh
+++ b/docs/automatic-appliance-tutorial/appliance-wizard.sh
@@ -132,7 +132,11 @@ WIZARD_ENV_FILE=""
 
 # Trap to ensure cursor is shown on exit AND the temp spec is removed on the
 # normal (successful) exit path, not only on interrupt.
-trap 'rm -f "$WIZARD_ENV_FILE"; show_cursor; stty echo 2>/dev/null' EXIT INT TERM
+# The trailing `|| true` matters: `stty` fails whenever stdin is not a terminal,
+# and under `set -e` a failing last command in the EXIT trap REPLACES the
+# script's exit status with 1 -- which would make a successful run report
+# failure and hide the deliberate non-zero exits below.
+trap 'rm -f "$WIZARD_ENV_FILE"; show_cursor; stty echo 2>/dev/null || true' EXIT INT TERM
 
 # Navigation result constants
 NAV_CONTINUE=0
@@ -202,6 +206,40 @@ print_warning() {
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# END-OF-INPUT GUARD
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# Every prompt in this wizard reads stdin inside a loop. On a non-interactive
+# stdin (a pipe, `</dev/null`, CI, `ssh host bash -s`) `read` returns non-zero
+# immediately with an empty value. Left unguarded the surrounding loops either
+# spin forever ("Required field" / "Invalid choice." in an unbounded loop) or
+# silently accept a default the user never chose.
+#
+# `set -e` cannot save us here: every step runs as `if ${steps[$current]}; then`,
+# a condition context, which disables errexit for the whole call tree. So each
+# read tests for end of input explicitly and aborts through this helper with
+# actionable guidance.
+#
+# Rule used at every call site: a final line with no trailing newline also makes
+# `read` return non-zero but DOES set a value, so only "non-zero AND empty"
+# counts as end of input.
+abort_on_eof() {
+    show_cursor
+    stty echo 2>/dev/null || true
+    echo ""
+    print_error "End of input: the wizard requires an interactive terminal."
+    local hint
+    for hint in "$@"; do
+        print_info "$hint"
+    done
+    exit 1
+}
+
+# Standard hint for the prompts that collect the appliance spec.
+NONINTERACTIVE_HINT_1="For non-interactive/CI use, write a spec file and run:"
+NONINTERACTIVE_HINT_2="  ./generate-docker-appliance.sh <spec>.env --no-build"
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # MENU SELECTOR (Arrow-key navigation)
 # ═══════════════════════════════════════════════════════════════════════════════
 
@@ -237,11 +275,23 @@ menu_select() {
     echo ""
     echo -e "  ${DIM}[↑↓] Navigate  [Enter] Select  [q] Quit${NC}"
 
+    local _ms_rc
     while true; do
-        IFS= read -rsn1 key
+        # EOF GUARD: at end of input `read` returns non-zero and leaves $key
+        # empty, which the `[ "$key" = "" ]` branch below treats exactly like
+        # pressing Enter -- the wizard would silently commit to option 0
+        # (ubuntu2204min) as if the user had picked it. Distinguish real EOF.
+        _ms_rc=0
+        IFS= read -rsn1 key || _ms_rc=$?
+        if [ $_ms_rc -ne 0 ] && [ -z "$key" ]; then
+            abort_on_eof \
+                "For non-interactive/CI use, set BASE_OS in a spec file and run:" \
+                "$NONINTERACTIVE_HINT_2"
+        fi
 
         if [ "$key" = $'\x1b' ]; then
-            read -rsn2 -t 0.1 key
+            # A bare Esc times out here; that is expected, not an error.
+            read -rsn2 -t 0.1 key || true
             case "$key" in
                 '[A') ((selected > 0)) && ((selected--)) ;;
                 '[B') ((selected < num_options - 1)) && ((selected++)) ;;
@@ -305,7 +355,14 @@ prompt_with_nav() {
             echo -ne "  ${prompt} ${DIM}(optional)${NC}: "
         fi
 
-        read -r value
+        # EOF GUARD (see abort_on_eof): without this, a required field with no
+        # default never gets a value, so the `required` branch below prints
+        # "Required field" and re-prompts in an unbounded loop.
+        local _rc=0
+        read -r value || _rc=$?
+        if [ $_rc -ne 0 ] && [ -z "$value" ]; then
+            abort_on_eof "$NONINTERACTIVE_HINT_1" "$NONINTERACTIVE_HINT_2"
+        fi
 
         case "${value,,}" in
             ':b'|':back'|'<') return $NAV_BACK ;;
@@ -349,7 +406,16 @@ prompt_yes_no() {
     [ -n "$current_val" ] && default="$current_val"
 
     echo -en "${CYAN}${prompt}${NC} ${DIM}[${default_hint}]${NC}: "
-    read -r value
+    # EOF GUARD (see abort_on_eof): on end of input `read` returns non-zero with
+    # an empty value, which would otherwise fall through to `*)` and silently
+    # answer the question with the default. `value` is deliberately local so one
+    # prompt cannot leak an answer into the next.
+    local value=""
+    local _rc=0
+    read -r value || _rc=$?
+    if [ $_rc -ne 0 ] && [ -z "$value" ]; then
+        abort_on_eof "$NONINTERACTIVE_HINT_1" "$NONINTERACTIVE_HINT_2"
+    fi
 
     case "${value,,}" in
         ':b'|':back'|'<') return $NAV_BACK ;;
@@ -416,15 +482,28 @@ step_welcome() {
     echo -e "  • Packer configuration for building the VM image"
     echo -e "  • Documentation and metadata for the marketplace\n"
     echo -e "${DIM}Prerequisites:${NC}"
-    echo -e "  • A Docker image available on Docker Hub (or other registry)"
-    echo -e "  • Basic information about your application\n"
+    echo -e "  • A Docker image on Docker Hub (or another registry), pinned to a"
+    echo -e "    fixed :tag or an @sha256 digest"
+    echo -e "  • Basic information about your application"
+    echo -e "  • To BUILD an image: a Linux host with /dev/kvm, run as root, and the"
+    echo -e "    one-apps build tooling — packer >= 1.9.4, qemu-utils, qemu-system-x86,"
+    echo -e "    libguestfs-tools, make, ruby, rpm, rsync, genisoimage, cloud-utils,"
+    echo -e "    cloud-image-utils, plus the 'backports' and 'fpm' gems"
+    echo -e "    ${DIM}Full list: https://github.com/OpenNebula/one-apps/wiki/tool_reqs${NC}"
+    echo -e "  • Initialised git submodules ${DIM}(the wizard runs this for you)${NC}\n"
     echo -e "${DIM}Navigation:${NC}"
     echo -e "  • Type ${CYAN}:b${NC} or ${CYAN}:back${NC} to go back to previous step"
     echo -e "  • Type ${CYAN}:q${NC} or ${CYAN}:quit${NC} to exit the wizard"
     echo -e "  • Use ${CYAN}↑/↓${NC} arrow keys for menu selections\n"
 
     echo -en "${YELLOW}Press Enter to continue or Ctrl+C to exit...${NC}"
-    read -r
+    # EOF GUARD (see abort_on_eof): fail here with a clear message rather than
+    # racing through every step on a non-interactive stdin.
+    local _rc=0
+    read -r || _rc=$?
+    if [ $_rc -ne 0 ] && [ -z "$REPLY" ]; then
+        abort_on_eof "$NONINTERACTIVE_HINT_1" "$NONINTERACTIVE_HINT_2"
+    fi
     return $NAV_CONTINUE
 }
 
@@ -439,9 +518,15 @@ step_docker_image() {
     print_info "':latest' and untagged names are rejected for reproducible builds."
     print_info "Examples:"
     print_info "  • nginx:1.25.3"
-    print_info "  • nodered/node-red:4.0.9"
-    print_info "  • nextcloud/all-in-one:20240813"
+    print_info "  • nodered/node-red:5.0.1"
+    print_info "  • redis:7.4.1-alpine"
     print_info "  • postgres:16-alpine"
+    print_info "  • nginx@sha256:<64-hex-digest>   (digest pin, strongest)"
+    echo ""
+    print_warning "Images that manage OTHER containers (nextcloud/all-in-one, portainer,"
+    print_warning "watchtower, traefik, ...) need /var/run/docker.sock bind-mounted, which"
+    print_warning "the generator rejects as a container-escape vector. Pinning the tag does"
+    print_warning "not help: they cannot be turned into an appliance with this tool."
     echo ""
 
     while true; do
@@ -516,7 +601,7 @@ step_appliance_info() {
 
     # Appliance name (lowercase, no spaces)
     print_info "Appliance name must be lowercase letters, numbers, and hyphens only."
-    print_info "Examples: nginx, node-red, nextcloud, postgres"
+    print_info "Examples: nginx, node-red, redis, postgres"
     echo ""
 
     while true; do
@@ -535,7 +620,7 @@ step_appliance_info() {
 
     echo ""
     print_info "Display name is what users will see in the marketplace."
-    print_info "Examples: NGINX, Node-RED, Nextcloud, PostgreSQL"
+    print_info "Examples: NGINX, Node-RED, Redis, PostgreSQL"
     echo ""
 
     prompt_required "Display name" APP_NAME
@@ -636,10 +721,57 @@ step_container_config() {
     echo ""
 
     print_info "Volume mappings in format: /host:/container,/host2:/container2"
-    print_info "Example: /data:/data or /config:/app/config"
-    prompt_optional "Volume mappings" DEFAULT_VOLUMES "/data:/data"
-    result=$?
-    [ $result -ne $NAV_CONTINUE ] && return $result
+    print_info "Example: /opt/${APPLIANCE_NAME:-app}/data:/var/lib/${APPLIANCE_NAME:-app}"
+    print_warning "Leave EMPTY unless the app needs persistence. Mounting an empty host"
+    print_warning "directory over a path the image ships (e.g. /etc/nginx/conf.d) HIDES"
+    print_warning "that content and the container starts with no configuration."
+    echo ""
+
+    # The generator hard-fails (exit 1) on any volume whose host path resolves
+    # under a protected system location. Mirror that list here so the user is
+    # told at THIS step instead of after all 7 steps and a temp spec have been
+    # written. Keep in sync with SENSITIVE_MOUNT_ROOTS in
+    # generate-docker-appliance.sh (bare /etc is intentionally NOT listed, so
+    # config-dir mounts like /etc/nginx/conf.d stay allowed).
+    local _sensitive_roots=(
+        /var/run/docker.sock /run/docker.sock
+        / /root /proc /sys /dev /boot
+        /var/run /run /usr /bin /sbin /lib /lib64 /var/lib/docker
+    )
+    local _bad _vol _host _root
+    local _vols=()
+    while true; do
+        # Default is EMPTY, matching the generator's own default and the fixed
+        # examples/nginx.env. The old "/data:/data" default silently mounted an
+        # empty host directory over whatever the image ships at /data.
+        prompt_optional "Volume mappings" DEFAULT_VOLUMES ""
+        result=$?
+        [ $result -ne $NAV_CONTINUE ] && return $result
+
+        _bad=""
+        if [ -n "$DEFAULT_VOLUMES" ]; then
+            _vols=()
+            IFS=',' read -ra _vols <<< "$DEFAULT_VOLUMES"
+            for _vol in "${_vols[@]}"; do
+                [ -z "$_vol" ] && continue
+                _host="${_vol%%:*}"
+                for _root in "${_sensitive_roots[@]}"; do
+                    if [ "$_host" = "$_root" ] || [[ "$_host" == "$_root"/* ]]; then
+                        _bad="$_host"
+                        break 2
+                    fi
+                done
+            done
+        fi
+
+        [ -z "$_bad" ] && break
+
+        print_error "Host path '$_bad' is a protected system location; the generator rejects it."
+        print_info "Mounting the Docker socket or a system directory is a container-escape vector."
+        print_info "Use an app-data path instead, e.g. /opt/${APPLIANCE_NAME:-app} or /srv/${APPLIANCE_NAME:-app}."
+        # Clear it so pressing Enter does not re-submit the rejected value.
+        DEFAULT_VOLUMES=""
+    done
 
     sleep 0.5
     return $NAV_CONTINUE
@@ -684,6 +816,11 @@ step_summary() {
     echo -e "${MAGENTA}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}\n"
     echo -e "${DIM}Type :b to go back and edit, or confirm to generate${NC}\n"
 
+    # CONFIRM is a global and prompt_yes_no reuses its current value as the next
+    # default. After one "n" it would stay "false", so pressing Enter at the
+    # summary bounces back to step 6 forever and the documented "[Enter] Next"
+    # could never generate. Reset it before every prompt.
+    CONFIRM=""
     prompt_yes_no "Generate appliance with this configuration?" CONFIRM "true"
     local result=$?
     [ $result -ne $NAV_CONTINUE ] && return $result
@@ -700,6 +837,23 @@ step_summary() {
 # ═══════════════════════════════════════════════════════════════════════════════
 # GENERATION & COMPLETION
 # ═══════════════════════════════════════════════════════════════════════════════
+
+# On a failure path, keep the temporary spec instead of letting the EXIT trap
+# delete it, and print where it is. The old handler claimed "Your inputs were
+# not lost" while `trap 'rm -f "$WIZARD_ENV_FILE"' EXIT` destroyed all 7 steps of
+# input and never showed the path.
+#
+# The spec deliberately stays in $TMPDIR (mode 600) instead of being copied into
+# the repository: DEFAULT_ENV_VARS may hold secrets and `*.env` is NOT gitignored
+# here (examples/*.env are committed), so a copy inside the tree could be picked
+# up by `git add -A`. See SECR-4 above.
+preserve_spec() {
+    local spec="$1"
+    WIZARD_ENV_FILE=""   # disarm the EXIT trap's `rm -f` for this file
+    print_info "Your answers were saved to: ${spec}"
+    print_info "It is mode 600 and outside the git tree because it may contain the"
+    print_info "environment variables you entered. Delete it once you are done."
+}
 
 generate_appliance() {
     clear_screen
@@ -743,16 +897,55 @@ WEB_INTERFACE="${WEB_INTERFACE}"
 ENVEOF
 
     if [ -f "${SCRIPT_DIR}/generate-docker-appliance.sh" ]; then
+        # The generator refuses to overwrite an existing appliance without
+        # --force. The wizard had no way to pass it, so a second run for the
+        # same name (common after a failed build, and unavoidable after a
+        # partially completed generation) was a permanent dead end. Detect the
+        # collision here and ask for the overwrite explicitly.
+        local gen_args=("$env_file" --no-build)
+        if [ -e "${REPO_ROOT}/appliances/${APPLIANCE_NAME}" ] || \
+           [ -e "${REPO_ROOT}/apps-code/community-apps/packer/${APPLIANCE_NAME}" ]; then
+            print_warning "Appliance '${APPLIANCE_NAME}' already exists and would be replaced."
+            if [ -t 0 ]; then
+                OVERWRITE=""
+                # generate_appliance is called as a plain command, so `set -e` is
+                # ACTIVE here. prompt_yes_no returns NAV_BACK(1)/NAV_QUIT(2) when
+                # the user types the documented `:b`/`:q`, and errexit would turn
+                # that into a silent exit with no message at all. Swallow the nav
+                # code and treat it as "do not overwrite".
+                prompt_yes_no "Overwrite the existing appliance?" OVERWRITE "false" || OVERWRITE="false"
+                if [ "$OVERWRITE" != "true" ]; then
+                    echo ""
+                    print_error "Aborted. Choose a different appliance name and re-run."
+                    preserve_spec "$env_file"
+                    return 1
+                fi
+            else
+                echo ""
+                print_error "Aborted: '${APPLIANCE_NAME}' exists and stdin is not a terminal."
+                print_info "Re-run non-interactively with:"
+                print_info "  ./generate-docker-appliance.sh <spec>.env --force --no-build"
+                preserve_spec "$env_file"
+                return 1
+            fi
+            gen_args+=(--force)
+        fi
+
         # REG-2: guard the generator call. The wizard runs under `set -e`, so an
         # unguarded non-zero exit would abort mid-flow (skipping the success
         # message and firing the EXIT trap) with only a raw generator [ERROR].
         # Surface the failure gracefully and keep the collected spec available.
-        if ! "${SCRIPT_DIR}/generate-docker-appliance.sh" "$env_file" --no-build; then
+        if ! "${SCRIPT_DIR}/generate-docker-appliance.sh" "${gen_args[@]}"; then
             echo ""
             print_error "Appliance generation failed (see the [ERROR] above)."
-            print_info "Your inputs were not lost. Fix the reported issue (commonly an"
-            print_info "unpinned Docker image or a sensitive default volume) and re-run."
-            return $NAV_CONTINUE
+            preserve_spec "$env_file"
+            print_info "Fix the reported issue (commonly an unpinned Docker image, a"
+            print_info "sensitive default volume, or an appliance name already in use),"
+            print_info "then re-run:"
+            print_info "  ./generate-docker-appliance.sh '${env_file}' --no-build"
+            # NOT $NAV_CONTINUE (0): returning 0 made the wizard exit 0 after a
+            # hard generator failure, so callers and CI saw a false success.
+            return 1
         fi
 
         echo ""
@@ -761,25 +954,50 @@ ENVEOF
         echo -e "  ${WHITE}Files:${NC}"
         echo -e "    appliances/${APPLIANCE_NAME}/"
         echo -e "    apps-code/community-apps/packer/${APPLIANCE_NAME}/"
+        echo -e "    apps-code/community-apps/Makefile.config ${DIM}(modified: ${APPLIANCE_NAME} added to SERVICES)${NC}"
         echo ""
         echo -e "  ${WHITE}Next:${NC}"
         echo -e "    1. Review generated files"
-        echo -e "    2. Build: ${CYAN}cd apps-code/community-apps && make ${APPLIANCE_NAME}${NC}"
+        echo -e "    2. Build: ${CYAN}cd apps-code/community-apps && sudo make ${APPLIANCE_NAME}${NC}"
+        echo -e "       ${DIM}(needs root: the build chroots. The base OS image is never built"
+        echo -e "        for you — if you skipped it: cd apps-code/one-apps && sudo make ${BASE_OS:-<base-os>})${NC}"
         echo -e "    3. Add logo: ${CYAN}logos/${APPLIANCE_NAME}.png${NC}"
-        echo -e "    4. Submit PR"
+        echo -e "    4. Submit PR — ${WHITE}commit Makefile.config too${NC}, otherwise"
+        echo -e "       ${DIM}'make ${APPLIANCE_NAME}' is not a valid target for reviewers${NC}"
         echo ""
 
-        prompt_yes_no "Build now?" BUILD_NOW "false"
+        # TTY GUARD: generate_appliance() is called as a plain command, so
+        # `set -e` is ACTIVE here. On a non-interactive stdin `read` returns
+        # non-zero and errexit would kill the wizard with exit 1 even though
+        # generation SUCCEEDED. Mirror the guard the generator already uses
+        # (`if [ -t 0 ]; then read ...; else REPLY="n"; fi`).
+        BUILD_NOW="false"
+        if [ -t 0 ]; then
+            # `|| BUILD_NOW="false"` for the same errexit reason as the overwrite
+            # prompt above: typing `:b`/`:q` here makes prompt_yes_no return a nav
+            # code, which under the ACTIVE errexit would kill the wizard with a
+            # bare exit 1 immediately after generation SUCCEEDED. Treat it as "no".
+            prompt_yes_no "Build now?" BUILD_NOW "false" || BUILD_NOW="false"
+        else
+            print_info "Non-interactive session: skipping the build prompt."
+            print_info "  Build later with: cd ${REPO_ROOT}/apps-code/community-apps && sudo make ${APPLIANCE_NAME}"
+        fi
 
         if [ "$BUILD_NOW" = "true" ]; then
             echo ""
-            echo -e "  Building... ${DIM}(~15-20 min)${NC}"
+            echo -e "  Building... ${DIM}(~2 min)${NC}"
             cd "${REPO_ROOT}/apps-code/community-apps"
-            make "$APPLIANCE_NAME"
+            if ! make "$APPLIANCE_NAME"; then
+                echo ""
+                print_error "Build failed. See the make output above."
+                print_info "Retry with: cd ${REPO_ROOT}/apps-code/community-apps && sudo make ${APPLIANCE_NAME}"
+                return 1
+            fi
+            print_success "Image built: ${REPO_ROOT}/apps-code/community-apps/export/${APPLIANCE_NAME}.qcow2"
         fi
     else
         print_error "Generator not found"
-        echo "  Config saved: ${env_file}"
+        preserve_spec "$env_file"
         exit 1
     fi
 }
@@ -822,20 +1040,31 @@ check_base_image() {
     echo -e "  ─────────────────────────────────────────────────────"
     echo ""
     echo -e "  ${WHITE}Options:${NC}"
-    echo -e "    ${CYAN}1.${NC} Build it now ${DIM}(~10-15 min, recommended)${NC}"
+    echo -e "    ${CYAN}1.${NC} Build it now ${DIM}(~3 min, recommended)${NC}"
     echo -e "    ${CYAN}2.${NC} Continue anyway ${DIM}(build manually later)${NC}"
     echo -e "    ${CYAN}3.${NC} Go back and choose a different base OS"
     echo ""
 
     local choice
+    local _bi_rc
     while true; do
         echo -ne "  ${WHITE}›${NC} Choose [1-3]: "
-        read -r choice
+        # EOF GUARD (see abort_on_eof): with a non-interactive stdin `read`
+        # returns non-zero and leaves $choice empty, which falls through to the
+        # `*)` branch below and re-prompts forever ("Invalid choice." in an
+        # unbounded loop).
+        _bi_rc=0
+        read -r choice || _bi_rc=$?
+        if [ $_bi_rc -ne 0 ] && [ -z "$choice" ]; then
+            abort_on_eof \
+                "Build the base image first, then re-run the wizard:" \
+                "  cd ${REPO_ROOT}/apps-code/one-apps && sudo make ${BASE_OS}"
+        fi
         case "$choice" in
             1)
                 echo ""
                 echo -e "  ${BRIGHT_CYAN}Building ${base_os_display} base image...${NC}"
-                echo -e "  ${DIM}This may take 10-15 minutes${NC}"
+                echo -e "  ${DIM}This usually takes about 3 minutes${NC}"
                 echo ""
 
                 # Build the base image
@@ -848,8 +1077,8 @@ check_base_image() {
                 else
                     echo ""
                     print_error "Base image build failed."
-                    echo -e "  ${DIM}You can try building it manually:${NC}"
-                    echo -e "  ${CYAN}cd ${REPO_ROOT}/apps-code/one-apps && make ${BASE_OS}${NC}"
+                    echo -e "  ${DIM}You can try building it manually (needs root — the build chroots):${NC}"
+                    echo -e "  ${CYAN}cd ${REPO_ROOT}/apps-code/one-apps && sudo make ${BASE_OS}${NC}"
                     echo ""
                     prompt_yes_no "Continue with appliance generation anyway?" CONTINUE_ANYWAY "false"
                     if [ "$CONTINUE_ANYWAY" = "true" ]; then
@@ -862,8 +1091,9 @@ check_base_image() {
             2)
                 echo ""
                 print_warning "Continuing without base image..."
-                echo -e "  ${DIM}Remember to build it before building the appliance:${NC}"
-                echo -e "  ${CYAN}cd ${REPO_ROOT}/apps-code/one-apps && make ${BASE_OS}${NC}"
+                echo -e "  ${DIM}Remember to build it before building the appliance"
+                echo -e "  ('make ${APPLIANCE_NAME}' never builds the base image for you):${NC}"
+                echo -e "  ${CYAN}cd ${REPO_ROOT}/apps-code/one-apps && sudo make ${BASE_OS}${NC}"
                 sleep 1
                 return 0
                 ;;
@@ -877,14 +1107,63 @@ check_base_image() {
     done
 }
 
-# Main wizard flow with navigation support
-main() {
+# Preflight: everything the wizard needs before it offers to run `make`.
+preflight_checks() {
+    local warned=false
+
     # Check if we're in the right directory
     if [ ! -f "${SCRIPT_DIR}/generate-docker-appliance.sh" ]; then
         echo -e "${RED}Error: This script must be run from the automatic-appliance-tutorial directory.${NC}"
         echo -e "Please cd to: ${SCRIPT_DIR}"
         exit 1
     fi
+
+    # PREFLIGHT 1 - host OS. The generator registers the appliance in
+    # apps-code/community-apps/Makefile.config with GNU `sed -i`; BSD/macOS sed
+    # fails there ("extra characters at the end of p command") AFTER every file
+    # has been written, leaving a half-created tree that then needs --force.
+    if [ "$(uname -s)" != "Linux" ]; then
+        print_error "This wizard must run on Linux: the generator needs GNU sed and the"
+        print_error "image build needs KVM. Detected: $(uname -s)."
+        exit 1
+    fi
+
+    # PREFLIGHT 2 - submodules. Without them apps-code/one-apps is empty and
+    # apps-code/community-apps/packer/build.sh is a dangling symlink, so every
+    # `make <target>` fails immediately.
+    if [ ! -f "${REPO_ROOT}/apps-code/one-apps/packer/build.sh" ]; then
+        print_warning "Git submodules are not initialized (apps-code/one-apps is empty)."
+        print_info "Initializing: git submodule update --init --recursive"
+        if ! git -C "${REPO_ROOT}" submodule update --init --recursive; then
+            print_error "Submodule init failed. Run it manually from ${REPO_ROOT}:"
+            print_error "  git submodule update --init --recursive"
+            exit 1
+        fi
+        print_success "Submodules initialized."
+        warned=true
+    fi
+
+    # PREFLIGHT 3 - build capability. Generation works without these; only the
+    # optional `make` steps need them, so warn rather than abort.
+    if [ "$(id -u)" -ne 0 ]; then
+        print_warning "Not running as root: image builds (which chroot) will fail."
+        print_info "Generation still works. To build, re-run the wizard with sudo."
+        warned=true
+    fi
+    if [ ! -e /dev/kvm ]; then
+        print_warning "/dev/kvm is missing: Packer cannot build VM images on this host."
+        print_info "Generation still works; build on a KVM-capable host."
+        warned=true
+    fi
+
+    # The first step clears the screen, so give the reader a moment.
+    [ "$warned" = "true" ] && sleep 3
+    return 0
+}
+
+# Main wizard flow with navigation support
+main() {
+    preflight_checks
 
     # Array of step functions
     local steps=(

--- a/docs/automatic-appliance-tutorial/examples/nginx.env
+++ b/docs/automatic-appliance-tutorial/examples/nginx.env
@@ -24,7 +24,12 @@ APP_FEATURES="High performance web server,Reverse proxy capabilities,Load balanc
 DEFAULT_CONTAINER_NAME="nginx-server"
 DEFAULT_PORTS="80:80,443:443"
 DEFAULT_ENV_VARS=""
-DEFAULT_VOLUMES="/etc/nginx/conf.d:/etc/nginx/conf.d,/var/www/html:/usr/share/nginx/html"
+# No default volumes: mounting empty host directories over the image's own
+# /etc/nginx/conf.d (default.conf) or /usr/share/nginx/html would hide the
+# image's built-in config and default page, leaving nginx with no server block
+# to serve. Add persistent volumes at instantiation only when you also provide
+# the content for them.
+DEFAULT_VOLUMES=""
 
 # Optional: Application settings
 APP_PORT="80"

--- a/docs/automatic-appliance-tutorial/examples/nodered.env
+++ b/docs/automatic-appliance-tutorial/examples/nodered.env
@@ -1,7 +1,9 @@
 # Node-Red Appliance Configuration
 
-# Required: Docker image to use
-DOCKER_IMAGE="nodered/node-red:latest"
+# Required: Docker image to use.
+# Pin an immutable tag: the generator rejects ':latest' (and untagged images)
+# so a rebuilt appliance always contains the exact version it claims.
+DOCKER_IMAGE="nodered/node-red:5.0.1"
 
 # Required: Appliance name (single lowercase word, no dashes)
 APPLIANCE_NAME="nodered"

--- a/docs/automatic-appliance-tutorial/generate-docker-appliance.sh
+++ b/docs/automatic-appliance-tutorial/generate-docker-appliance.sh
@@ -518,6 +518,22 @@ CONTAINER_VOLUMES_Y="$(yaml_squote "$DEFAULT_VOLUMES")"
 
 print_success "Directory structure created"
 
+# Certification-safe copies of the list-valued defaults.
+#
+# lib/community/app_handler.rb builds the test context by joining every
+# metadata :params: entry with COMMAS and handing the result to
+# `onetemplate instantiate --context "..."`. The OpenNebula CLI splits that
+# string on commas regardless of quoting, so a value that itself contains a
+# comma is truncated there (e.g. '80:80,443:443' arrives as '80:80,' and the
+# 443 mapping silently disappears during certification).
+#
+# Emit these defaults separated by ';' instead. appliance.sh accepts BOTH ','
+# and ';' as list separators, so the documented comma form still works for
+# operators entering values in Sunstone.
+CERT_PORTS="${DEFAULT_PORTS//,/;}"
+CERT_ENV="${DEFAULT_ENV_VARS//,/;}"
+CERT_VOLUMES="${DEFAULT_VOLUMES//,/;}"
+
 # Generate metadata.yaml
 print_info "📝 Generating metadata.yaml..."
 cat > "$REPO_ROOT/appliances/$APPLIANCE_NAME/metadata.yaml" << EOF
@@ -530,12 +546,19 @@ cat > "$REPO_ROOT/appliances/$APPLIANCE_NAME/metadata.yaml" << EOF
     :base: $BASE_OS
   :hypervisor: KVM
   :context:
+    # ':prefixed: true' means the test harness ADDS the ONEAPP_ prefix itself
+    # (lib/community/app_handler.rb -> app_context()), so the parameter names
+    # below must be written WITHOUT it. Writing them pre-prefixed yields
+    # ONEAPP_ONEAPP_* and the appliance receives no configuration at all.
     :prefixed: true
+    # List values use ';' here on purpose: the harness joins these with commas
+    # before passing them to 'onetemplate instantiate --context', which splits
+    # on commas. appliance.sh accepts ',' and ';' interchangeably.
     :params:
-      :ONEAPP_CONTAINER_NAME: '$DEFAULT_CONTAINER_NAME'
-      :ONEAPP_CONTAINER_PORTS: '$DEFAULT_PORTS'
-      :ONEAPP_CONTAINER_ENV: '$DEFAULT_ENV_VARS'
-      :ONEAPP_CONTAINER_VOLUMES: '$DEFAULT_VOLUMES'
+      :CONTAINER_NAME: '$DEFAULT_CONTAINER_NAME'
+      :CONTAINER_PORTS: '$CERT_PORTS'
+      :CONTAINER_ENV: '$CERT_ENV'
+      :CONTAINER_VOLUMES: '$CERT_VOLUMES'
 
 :one:
   :template:
@@ -1108,7 +1131,7 @@ setup_app_container()
 
     # Parse port mappings
     if [ -n "$container_ports" ]; then
-        IFS=',' read -ra PORT_ARRAY <<< "$container_ports"
+        IFS=',;' read -ra PORT_ARRAY <<< "$container_ports"
         for port in "${PORT_ARRAY[@]}"; do
             [ -n "$port" ] && run_args+=( -p "$port" )
         done
@@ -1116,7 +1139,7 @@ setup_app_container()
 
     # Parse environment variables
     if [ -n "$container_env" ]; then
-        IFS=',' read -ra ENV_ARRAY <<< "$container_env"
+        IFS=',;' read -ra ENV_ARRAY <<< "$container_env"
         for env in "${ENV_ARRAY[@]}"; do
             [ -n "$env" ] && run_args+=( -e "$env" )
         done
@@ -1140,7 +1163,7 @@ setup_app_container()
             / /root /proc /sys /dev /boot
             /var/run /run /usr /bin /sbin /lib /lib64 /var/lib/docker
         )
-        IFS=',' read -ra VOL_ARRAY <<< "$container_volumes"
+        IFS=',;' read -ra VOL_ARRAY <<< "$container_volumes"
         for vol in "${VOL_ARRAY[@]}"; do
             [ -z "$vol" ] && continue
             local host_path="${vol%%:*}"
@@ -1578,28 +1601,32 @@ require_relative '../../../lib/community/app_handler'
 describe 'Appliance Certification' do
     include_context('vm_handler')
 
+    # The VM answers SSH before the appliance has finished its bootstrap, so
+    # every check retries until it succeeds instead of asserting once. Without
+    # this the suite is racy: 'systemctl is-active docker' in particular can be
+    # queried while docker is still starting.
+    def wait_for(description, cmd, timeout = 180)
+        start_time = Time.now
+        loop do
+            result = @info[:vm].ssh(cmd)
+            return result if result.success?
+            raise "#{description} not satisfied within #{timeout}s (last: #{cmd})" if Time.now - start_time > timeout
+            sleep 5
+        end
+    end
+
     it 'docker engine is active' do
-        result = @info[:vm].ssh('systemctl is-active docker')
-        expect(result.success?).to be(true)
+        wait_for('docker active', 'systemctl is-active docker')
     end
 
     it '$APP_NAME image ($DOCKER_IMAGE) is present' do
-        cmd = "docker images --format '{{.Repository}}:{{.Tag}}' | grep -F '$DOCKER_IMAGE'"
-        result = @info[:vm].ssh(cmd)
-        expect(result.success?).to be(true)
+        wait_for('image present',
+                 "docker images --format '{{.Repository}}:{{.Tag}}' | grep -F '$DOCKER_IMAGE'")
     end
 
     it '$APP_NAME container ($DEFAULT_CONTAINER_NAME) is running' do
-        cmd = "docker ps --format '{{.Names}}' | grep -Fx '$DEFAULT_CONTAINER_NAME'"
-        start_time = Time.now
-        timeout = 180
-
-        loop do
-            result = @info[:vm].ssh(cmd)
-            break if result.success?
-            raise "container $DEFAULT_CONTAINER_NAME not running within #{timeout}s" if Time.now - start_time > timeout
-            sleep 5
-        end
+        wait_for('container running',
+                 "docker ps --format '{{.Names}}' | grep -Fx '$DEFAULT_CONTAINER_NAME'")
     end
 end
 EOF

--- a/docs/automatic-appliance-tutorial/generate-docker-appliance.sh
+++ b/docs/automatic-appliance-tutorial/generate-docker-appliance.sh
@@ -21,12 +21,21 @@ show_usage() {
     cat << EOF
 🚀 Ultimate OpenNebula Docker Appliance Generator
 
-Usage: $0 <config-file>
+Usage: $0 <config-file> [--no-build] [--force] [-h|--help]
 
 Creates ALL necessary files for a complete Docker-based OpenNebula appliance.
 
+Options:
+    --no-build   Do not offer to build the image afterwards. Use this for
+                 scripted / CI runs. (Interactive runs prompt; a run with no
+                 terminal on stdin skips the prompt automatically.)
+    --force      Regenerate an appliance that already exists. The previous
+                 appliances/<name>/ and packer/<name>/ directories are removed
+                 first, so no stale <uuid>.yaml is left behind.
+    -h, --help   Show this help.
+
 Example config file (nginx.env):
-    DOCKER_IMAGE="nginx:alpine"
+    DOCKER_IMAGE="nginx:alpine"        # must be pinned; ':latest' is rejected
     APPLIANCE_NAME="nginx"
     APP_NAME="NGINX Web Server"
     PUBLISHER_NAME="Your Name"
@@ -36,9 +45,21 @@ Example config file (nginx.env):
     DEFAULT_CONTAINER_NAME="nginx-server"
     DEFAULT_PORTS="80:80,443:443"
     DEFAULT_ENV_VARS=""
-    DEFAULT_VOLUMES="/etc/nginx/conf.d:/etc/nginx/conf.d"
+    DEFAULT_VOLUMES=""                 # see the note below
     APP_PORT="80"
     WEB_INTERFACE="true"
+    BASE_OS="ubuntu2204min"            # optional, this is the default
+
+BASE_OS selects the base image the appliance is built on. It must already be
+built in apps-code/one-apps (e.g. 'cd apps-code/one-apps && make ubuntu2204min').
+Supported: ubuntu2204min ubuntu2204 ubuntu2404min ubuntu2404 debian12 debian11
+           alma8 alma9 rocky8 rocky9 opensuse15
+
+DEFAULT_VOLUMES: only declare a volume you actually populate. Mounting an empty
+host directory over a path the image ships content in (for example nginx's
+/etc/nginx/conf.d or /usr/share/nginx/html) HIDES that content and the service
+starts with nothing to serve. Volumes the appliance creates are chowned to the
+UID/GID the container image runs as.
 
 This will generate:
 ✅ All appliance files (metadata, appliance.sh, README, CHANGELOG)
@@ -46,6 +67,9 @@ This will generate:
 ✅ All test files
 ✅ Complete directory structure
 ✅ Ready-to-build appliance
+
+Then build it with:
+    cd apps-code/community-apps && sudo make <APPLIANCE_NAME>
 
 EOF
 }
@@ -461,6 +485,11 @@ if [ "$FORCE" != "true" ]; then
         print_info "Refusing to overwrite. Re-run with --force to replace it."
         exit 1
     fi
+else
+    # --force: remove any previous generation first. The appliance UUID is
+    # random per run, so a plain overwrite would leave the OLD <uuid>.yaml
+    # behind and accumulate stale descriptors. Start from a clean directory.
+    rm -rf "$APPLIANCE_DIR" "$PACKER_DIR"
 fi
 
 # Create directories (absolute paths from repository root)
@@ -497,32 +526,43 @@ cat > "$REPO_ROOT/appliances/$APPLIANCE_NAME/metadata.yaml" << EOF
   :name: $APPLIANCE_NAME
   :type: service
   :os:
-    - $OS_ID
-    - '$OS_RELEASE'
-  :arch:
-    - x86_64
-  :format: qcow2
-  :hypervisor:
-    - KVM
-  :opennebula_version:
-    - '7.0'
-  :opennebula_template:
-    context:
-      - SSH_PUBLIC_KEY="\$USER[SSH_PUBLIC_KEY]"
-      - SET_HOSTNAME="\$USER[SET_HOSTNAME]"
-    cpu: '2'
-    memory: '2048'
-    disk_size: '8192'
-    graphics:
-      listen: 0.0.0.0
-      type: vnc
-    inputs_order: 'CONTAINER_NAME,CONTAINER_PORTS,CONTAINER_ENV,CONTAINER_VOLUMES'
-    logo: logos/$APPLIANCE_NAME.png
-    user_inputs:
-      CONTAINER_NAME: 'M|text|Container name|$DEFAULT_CONTAINER_NAME|$DEFAULT_CONTAINER_NAME'
-      CONTAINER_PORTS: 'M|text|Container ports (format: host:container)|$DEFAULT_PORTS|$DEFAULT_PORTS'
-      CONTAINER_ENV: 'O|text|Environment variables (format: VAR1=value1,VAR2=value2) - may contain secrets, provide at instantiation|'
-      CONTAINER_VOLUMES: 'O|text|Volume mounts (format: /host/path:/container/path)|$DEFAULT_VOLUMES|'
+    :type: linux
+    :base: $BASE_OS
+  :hypervisor: KVM
+  :context:
+    :prefixed: true
+    :params:
+      :ONEAPP_CONTAINER_NAME: '$DEFAULT_CONTAINER_NAME'
+      :ONEAPP_CONTAINER_PORTS: '$DEFAULT_PORTS'
+      :ONEAPP_CONTAINER_ENV: '$DEFAULT_ENV_VARS'
+      :ONEAPP_CONTAINER_VOLUMES: '$DEFAULT_VOLUMES'
+
+:one:
+  :template:
+    NAME: base
+    TEMPLATE:
+      ARCH: x86_64
+      CONTEXT:
+        NETWORK: 'YES'
+        SET_HOSTNAME: "\$NAME"
+        SSH_PUBLIC_KEY: "\$USER[SSH_PUBLIC_KEY]"
+      CPU: '2'
+      CPU_MODEL:
+        MODEL: host-passthrough
+      GRAPHICS:
+        LISTEN: 0.0.0.0
+        TYPE: vnc
+      MEMORY: '2048'
+      NIC:
+        NETWORK: service
+      NIC_DEFAULT:
+        MODEL: virtio
+  :datastore_name: default
+  :timeout: '600'
+
+:infra:
+  :disk_format: qcow2
+  :apps_path: /var/tmp
 EOF
 
 # Generate UUID.yaml (main appliance metadata)
@@ -604,6 +644,10 @@ opennebula_template:
     network: 'YES'
     ssh_public_key: \$USER[SSH_PUBLIC_KEY]
     set_hostname: \$USER[SET_HOSTNAME]
+    oneapp_container_name: "\$ONEAPP_CONTAINER_NAME"
+    oneapp_container_ports: "\$ONEAPP_CONTAINER_PORTS"
+    oneapp_container_env: "\$ONEAPP_CONTAINER_ENV"
+    oneapp_container_volumes: "\$ONEAPP_CONTAINER_VOLUMES"
   cpu: '2'
   disk:
     image: \$FILE[IMAGE_ID]
@@ -614,11 +658,11 @@ opennebula_template:
   memory: '2048'
   name: $APP_NAME_Y
   user_inputs:
-    - CONTAINER_NAME: 'M|text|Container name|$DEFAULT_CONTAINER_NAME|$DEFAULT_CONTAINER_NAME'
-    - CONTAINER_PORTS: 'M|text|Container ports (format: host:container)|$DEFAULT_PORTS|$DEFAULT_PORTS'
-    - CONTAINER_ENV: 'O|text|Environment variables (format: VAR1=value1,VAR2=value2) - may contain secrets, provide at instantiation|'
-    - CONTAINER_VOLUMES: 'O|text|Volume mounts (format: /host/path:/container/path)|$DEFAULT_VOLUMES|'
-  inputs_order: CONTAINER_NAME,CONTAINER_PORTS,CONTAINER_ENV,CONTAINER_VOLUMES
+    oneapp_container_name: 'M|text|Container name|$DEFAULT_CONTAINER_NAME|$DEFAULT_CONTAINER_NAME'
+    oneapp_container_ports: 'M|text|Container ports (format: host:container)|$DEFAULT_PORTS|$DEFAULT_PORTS'
+    oneapp_container_env: 'O|text|Environment variables (format: VAR1=value1,VAR2=value2)||$DEFAULT_ENV_VARS'
+    oneapp_container_volumes: 'O|text|Volume mounts (format: /host/path:/container/path)||$DEFAULT_VOLUMES'
+  inputs_order: ONEAPP_CONTAINER_NAME,ONEAPP_CONTAINER_PORTS,ONEAPP_CONTAINER_ENV,ONEAPP_CONTAINER_VOLUMES
 logo: logos/$APPLIANCE_NAME.png
 EOF
 
@@ -1144,6 +1188,35 @@ setup_app_container()
             # do NOT chown -R an existing host tree (removed).
             if [ ! -e "$resolved" ]; then
                 mkdir -p "$resolved"
+
+                # Most official images run their workload as a NON-root user
+                # (node-red, postgres, redis...). A directory we just created is
+                # owned by root with umask 077 (0700), so that user cannot read
+                # or write its own state directory and the container crash-loops
+                # (e.g. node-red: "EACCES: permission denied, lstat
+                # '/data/settings.js'"). Hand the new directory to the UID/GID
+                # the image actually runs as. This is applied ONLY to a
+                # directory just created here, never to a pre-existing host tree.
+                local _img_user _img_uid _img_gid _ids
+                _img_user="$(docker inspect -f '{{.Config.User}}' "$DOCKER_IMAGE" 2>/dev/null)"
+                _img_uid=""; _img_gid=""
+                case "$_img_user" in
+                    '')   : ;;                                   # runs as root: nothing to do
+                    *[!0-9:]*)                                   # a NAME: resolve it inside the image
+                        _ids="$(docker run --rm --entrypoint /bin/sh "$DOCKER_IMAGE" \
+                                    -c 'id -u; id -g' 2>/dev/null | tr '\n' ' ')"
+                        _img_uid="$(printf '%s' "$_ids" | awk '{print $1}')"
+                        _img_gid="$(printf '%s' "$_ids" | awk '{print $2}')"
+                        ;;
+                    *)    _img_uid="${_img_user%%:*}"             # already numeric
+                          _img_gid="${_img_user##*:}"
+                          [ "$_img_gid" = "$_img_uid" ] && _img_gid="$_img_uid"
+                          ;;
+                esac
+                if [ -n "$_img_uid" ] && [ "$_img_uid" != "0" ]; then
+                    chown "$_img_uid:${_img_gid:-$_img_uid}" "$resolved" 2>/dev/null || true
+                    msg info "  Volume $resolved owned by container user ${_img_uid}:${_img_gid:-$_img_uid}"
+                fi
             fi
             run_args+=( -v "$vol" )
         done
@@ -1187,38 +1260,23 @@ print_success "appliance.sh generated (simplified Phoenix RTOS/Node-RED structur
 # Generate basic Packer files
 print_info "📝 Generating Packer configuration files..."
 
-# DEF-6 / SECR-8: the Packer QEMU communicator needs to SSH into the VM during
-# the build only. Instead of a fixed, published password we generate a random
-# per-build password used solely by the build-time context ISO and the Packer
-# communicator. It is not the deployed VM's credential: the deployed VM relies
-# on context-injected SSH keys (see 81-configure-ssh.sh, which re-hardens sshd
-# during the build).
-#
-# DEF-4 / CMP-SECR-8: this random password IS written in cleartext into the
-# local build files gen_context and <name>.pkr.hcl (Packer must read it to
-# connect). Those two files live under the git-tracked packer/<name>/ dir, so
-# we drop a .gitignore below to keep them (and the credential) OUT of version
-# control. It is NOT written to human-facing files (README, metadata, welcome
-# banner).
-BUILD_SSH_PASSWORD="$(LC_ALL=C tr -dc 'A-Za-z0-9' < /dev/urandom | head -c 24 || true)"
-if [ -z "$BUILD_SSH_PASSWORD" ]; then
-    BUILD_SSH_PASSWORD="$(uuidgen | tr -d '-')"
-fi
-
-# DEF-4 / CMP-SECR-8: prevent the build password (in gen_context and the
-# .pkr.hcl) from being committed. Write a .gitignore in the generated packer
-# dir that excludes the two password-bearing files. The build still works
-# (Packer reads them from disk); an accidental `git add -A` cannot leak them.
+# Build-time SSH credential. The Packer QEMU communicator SSHes into the
+# transient build VM as root to run the provisioners. Like every other
+# community appliance (see packer/example), we use the well-known build-only
+# password "opennebula": it exists only on the localhost-bound build VM, is
+# never the deployed VM's credential (the appliance boots SSH-key-only via
+# context), and 81-configure-ssh.sh re-hardens sshd during the build. Because
+# it is not a deployed secret, gen_context and <name>.pkr.hcl are committed
+# like the rest of the build definition, so the appliance can be rebuilt from
+# the PR.
 cat > "$REPO_ROOT/apps-code/community-apps/packer/$APPLIANCE_NAME/.gitignore" << GITIGNORE_EOF
-# DEF-4 / CMP-SECR-8 / DEF-1: these generated files (and the build-time
-# artifacts derived from gen_context) embed the random per-build SSH password
-# in cleartext. Keep them all out of version control.
-gen_context
-${APPLIANCE_NAME}.pkr.hcl
-context.sh
+# Transient build artifacts produced by 'make ${APPLIANCE_NAME}': the context
+# staging dir and the generated context ISO. The build definition itself
+# (${APPLIANCE_NAME}.pkr.hcl, gen_context, variables.pkr.hcl and the *.sh
+# provisioners) IS tracked so the appliance can be rebuilt from the PR.
 context/
+context.sh
 *-context.iso
-*.iso
 GITIGNORE_EOF
 
 # Generate variables.pkr.hcl
@@ -1296,7 +1354,7 @@ source "qemu" "$APPLIANCE_NAME" {
   ]
 
   ssh_username     = "root"
-  ssh_password     = "${BUILD_SSH_PASSWORD}"
+  ssh_password     = "opennebula"
   ssh_timeout     = "900s"
   shutdown_command = "poweroff"
   vm_name          = var.appliance_name
@@ -1454,7 +1512,7 @@ cat<<CTXEOF
 ETH0_METHOD='dhcp'
 NETWORK='YES'
 SET_HOSTNAME='${APPLIANCE_NAME}'
-PASSWORD='${BUILD_SSH_PASSWORD}'
+PASSWORD='opennebula'
 ETH0_MAC='00:11:22:33:44:55'
 NETCFG_TYPE='${NETCFG_TYPE}'
 START_SCRIPT_BASE64="\$(echo "\$SCRIPT" | base64 -w0)"
@@ -1506,31 +1564,43 @@ EOF
 # Generate tests.yaml
 cat > "$REPO_ROOT/appliances/$APPLIANCE_NAME/tests.yaml" << EOF
 ---
-- 00-$APPLIANCE_NAME\_basic.rb
+- 00-${APPLIANCE_NAME}_basic.rb
 EOF
 
 # Generate basic test file
 cat > "$REPO_ROOT/appliances/$APPLIANCE_NAME/tests/00-${APPLIANCE_NAME}_basic.rb" << EOF
-# Basic test for $APP_NAME appliance
+# Certification tests for the $APP_NAME Docker appliance.
+# Uses the community RSpec harness (lib/community/app_handler + vm_handler),
+# the same framework the other appliances in this repo are tested with.
 
-require_relative '../../../lib/tests'
+require_relative '../../../lib/community/app_handler'
 
-class Test${APPLIANCE_NAME^} < Test
-  def test_docker_installed
-    assert_cmd('docker --version')
-  end
+describe 'Appliance Certification' do
+    include_context('vm_handler')
 
-  def test_docker_running
-    assert_cmd('systemctl is-active docker')
-  end
+    it 'docker engine is active' do
+        result = @info[:vm].ssh('systemctl is-active docker')
+        expect(result.success?).to be(true)
+    end
 
-  def test_image_pulled
-    assert_cmd("docker images | grep '$DOCKER_IMAGE'")
-  end
+    it '$APP_NAME image ($DOCKER_IMAGE) is present' do
+        cmd = "docker images --format '{{.Repository}}:{{.Tag}}' | grep -F '$DOCKER_IMAGE'"
+        result = @info[:vm].ssh(cmd)
+        expect(result.success?).to be(true)
+    end
 
-  def test_container_running
-    assert_cmd("docker ps | grep '$DEFAULT_CONTAINER_NAME'")
-  end
+    it '$APP_NAME container ($DEFAULT_CONTAINER_NAME) is running' do
+        cmd = "docker ps --format '{{.Names}}' | grep -Fx '$DEFAULT_CONTAINER_NAME'"
+        start_time = Time.now
+        timeout = 180
+
+        loop do
+            result = @info[:vm].ssh(cmd)
+            break if result.success?
+            raise "container $DEFAULT_CONTAINER_NAME not running within #{timeout}s" if Time.now - start_time > timeout
+            sleep 5
+        end
+    end
 end
 EOF
 
@@ -1541,16 +1611,16 @@ EOF
 # CONTAINER_ENV default.
 # BYP-2: emit each context.yaml scalar single-quoted (`'`->`''`) so structural
 # chars in the interpolated values cannot corrupt or break the YAML document.
-CONTEXT_ENV_LINE="CONTAINER_ENV:"
-CONTEXT_VOLUMES_LINE="CONTAINER_VOLUMES:"
+CONTEXT_ENV_LINE="ONEAPP_CONTAINER_ENV:"
+CONTEXT_VOLUMES_LINE="ONEAPP_CONTAINER_VOLUMES:"
 if [ -n "$DEFAULT_VOLUMES" ]; then
-    CONTEXT_VOLUMES_LINE="CONTAINER_VOLUMES: $CONTAINER_VOLUMES_Y"
+    CONTEXT_VOLUMES_LINE="ONEAPP_CONTAINER_VOLUMES: $CONTAINER_VOLUMES_Y"
 fi
 
 cat > "$REPO_ROOT/appliances/$APPLIANCE_NAME/context.yaml" << EOF
 ---
-CONTAINER_NAME: $CONTAINER_NAME_Y
-CONTAINER_PORTS: $CONTAINER_PORTS_Y
+ONEAPP_CONTAINER_NAME: $CONTAINER_NAME_Y
+ONEAPP_CONTAINER_PORTS: $CONTAINER_PORTS_Y
 $CONTEXT_ENV_LINE
 $CONTEXT_VOLUMES_LINE
 EOF
@@ -1618,9 +1688,19 @@ if [ "$NO_BUILD" = true ]; then
     exit 0
 fi
 
-# Ask user if they want to build the image now
-read -p "$(echo -e "${BLUE}Do you want to build the image now? (y/n):${NC} ")" -n 1 -r
-echo
+# Ask user if they want to build the image now. Only prompt when stdin is a
+# real terminal: piped/CI/SSH-`bash -s` runs have no TTY, where `read` returns
+# EOF immediately and would otherwise fail the script even though generation
+# succeeded. Non-interactive runs skip the build (use --no-build to silence
+# this note, or run `make $APPLIANCE_NAME` yourself).
+if [ -t 0 ]; then
+    read -p "$(echo -e "${BLUE}Do you want to build the image now? (y/n):${NC} ")" -n 1 -r
+    echo
+else
+    print_info "Non-interactive session: skipping the build prompt."
+    print_info "  Build later with: cd $REPO_ROOT/apps-code/community-apps && make $APPLIANCE_NAME"
+    REPLY="n"
+fi
 if [[ $REPLY =~ ^[Yy]$ ]]; then
     print_info "🔨 Preparing to build the image..."
 

--- a/docs/automatic-appliance-tutorial/generate-docker-appliance.sh
+++ b/docs/automatic-appliance-tutorial/generate-docker-appliance.sh
@@ -49,11 +49,18 @@ Example config file (nginx.env):
     APP_PORT="80"
     WEB_INTERFACE="true"
     BASE_OS="ubuntu2204min"            # optional, this is the default
+    DISK_SIZE="20480"                  # optional, MiB, this is the default
 
 BASE_OS selects the base image the appliance is built on. It must already be
 built in apps-code/one-apps (e.g. 'cd apps-code/one-apps && make ubuntu2204min').
 Supported: ubuntu2204min ubuntu2204 ubuntu2404min ubuntu2404 debian12 debian11
            alma8 alma9 rocky8 rocky9 opensuse15
+
+DISK_SIZE is the appliance's virtual disk size in MiB. Packer can only GROW the
+base image, so this must be >= the base image's virtual size (ubuntu2204min is
+2.2 GiB, alma9 is 10 GiB). A smaller value aborts the build with
+"Error creating hard drive: qemu-img: Use the --shrink option ...". qcow2 is
+sparse, so a generous size does not enlarge the exported file.
 
 DEFAULT_VOLUMES: only declare a volume you actually populate. Mounting an empty
 host directory over a path the image ships content in (for example nginx's
@@ -177,6 +184,7 @@ parse_config_file() {
             APP_PORT)                APP_PORT="$value" ;;
             WEB_INTERFACE)           WEB_INTERFACE="$value" ;;
             BASE_OS)                 BASE_OS="$value" ;;
+            DISK_SIZE)               DISK_SIZE="$value" ;;
             DEFAULT_CONTAINER_NAME|CONTAINER_NAME) DEFAULT_CONTAINER_NAME="$value" ;;
             DEFAULT_PORTS)           DEFAULT_PORTS="$value" ;;
             CONTAINER_PORTS|PORTS)   DEFAULT_PORTS="$value" ;;
@@ -292,6 +300,16 @@ WEB_INTERFACE="${WEB_INTERFACE:-true}"
 APP_DESCRIPTION="${APP_DESCRIPTION:-Docker-based appliance for ${APP_NAME}}"
 APP_FEATURES="${APP_FEATURES:-Containerized application,Easy deployment,Configurable parameters}"
 BASE_OS="${BASE_OS:-ubuntu2204min}"
+
+# Virtual disk size (MiB) of the appliance image.
+#
+# Packer can only GROW the base image's disk. The supported base images differ
+# a lot here (ubuntu2204min is 2.2 GiB, alma9 is 10 GiB), and asking for less
+# than the base already has aborts the build with
+#   "Error creating hard drive: qemu-img: Use the --shrink option ..."
+# so the default must clear the largest base. qcow2 is sparse, so a generous
+# virtual size costs nothing in the exported file.
+DISK_SIZE="${DISK_SIZE:-20480}"
 
 # Define supported base OS images with their metadata
 declare -A OS_DISPLAY_NAMES=(
@@ -1363,7 +1381,7 @@ source "qemu" "$APPLIANCE_NAME" {
   net_device       = "virtio-net"
   format           = "qcow2"
   disk_compression = false
-  disk_size        = "8000"
+  disk_size        = "${DISK_SIZE}"
 
   output_directory = var.output_dir
 


### PR DESCRIPTION
The generator merged in #129 could not be used as documented: a fresh clone never
built, and the PR the guide told contributors to open shipped without a build
definition. Everything here was verified by running it on a Linux + KVM host.

Fixes:

- No guide mentioned `git submodule update --init --recursive` or the base image
  build, and the prerequisites omitted `fpm`, `rpm`, `cloud-image-utils` and Packer.
- `metadata.yaml` used a schema nothing reads; now `:app:` / `:one:` / `:infra:`.
- Its `:params:` were pre-prefixed, so the harness sent `ONEAPP_ONEAPP_*` and the
  appliance received no configuration.
- The harness joins params with commas and the CLI splits on them, truncating lists
  (`80:80,443:443` arrived as `80:80,`); use `;` and accept both separators.
- `<uuid>.yaml` `user_inputs` was a sequence and never reached `context`, so operator
  input was ignored.
- The emitted `.gitignore` excluded `<name>.pkr.hcl` and `gen_context`, leaving the
  contributor's PR unbuildable.
- Volume directories were created `root:root 0700`, crash-looping every image that
  runs unprivileged.
- `disk_size` was hardcoded to 8 GB, aborting on any larger base (alma9 is 10 GiB).
- `nginx.env` mounted empty dirs over the image's own config; `nodered.env` used
  `:latest`, which the generator rejects.
- The wizard looped forever on EOF; the generator exited 1 on success without a TTY.
- The generated rspec test referenced a class that does not exist.

Docs rewritten to the verified sequence, including how to run the certification
tests (as `oneadmin`, with a readable `IMAGES_URL` and a `base` template).

Verified: fresh clone → `ubuntu2204min` and `alma9` base images → all four examples
build and boot (nginx 200, postgres `psql`, redis `PONG`, nodered 200) → certification
`3 examples, 0 failures` → operator inputs applied at instantiation.
